### PR TITLE
Add the install CLI and Expo config plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Provides a `jsi::Runtime` backed by quickjs-ng, and the `JSRuntimeFactory` glue
 React Native uses to select it. The engine is compiled from source as part of
 the app build. Neither Hermes nor JavaScriptCore is linked into the result.
 
-> **Alpha.** Setup is manual on both platforms. See
-> [Known limitations](#known-limitations). Breaking changes are expected.
+> **Alpha.** See [Known limitations](#known-limitations). Breaking changes are
+> expected.
 
 ## Requirements
 
@@ -31,9 +31,21 @@ the app build. Neither Hermes nor JavaScriptCore is linked into the result.
 
 ```sh
 npm install @react-native-quickjs/quickjs
+npx react-native-quickjs install
+cd ios && pod install
 ```
 
-Both platform sections below are required.
+For Expo, add the config plugin instead and run `expo prebuild`:
+
+```json
+{ "expo": { "plugins": ["@react-native-quickjs/quickjs"] } }
+```
+
+`npx react-native-quickjs doctor` reports which parts are configured, and
+`revert` puts the app back on Hermes.
+
+The two sections below are the changes `install` makes. Follow them by hand if
+you would rather, or if `install` reports a file it could not edit.
 
 ## iOS
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Expo resolves a plugin referenced by package name to app.plugin.js at the
+ * package root.
+ */
+
+module.exports = require('./scripts/expo/plugin.js');

--- a/bin/react-native-quickjs.js
+++ b/bin/react-native-quickjs.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const run = require('../scripts/setup/run.js');
+const [command, ...argv] = process.argv.slice(2);
+
+if (command in run) {
+  process.exit(run[command](argv));
+}
+
+console.log(`
+react-native-quickjs
+
+  install   configure this app to run on QuickJS
+  revert    configure it back to Hermes
+  doctor    report which parts are configured
+
+  --project <path>   act on this app instead of the current directory
+  --dry-run          show what would change, write nothing
+`);
+process.exit(command === undefined || command === '--help' || command === '-h' ? 0 : 1);

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: 'Run your React Native app on QuickJS instead of Hermes. Full Chrom
 hero:
   name: react-native-quickjs
   text: Run React Native on QuickJS.
-  tagline: A drop-in JavaScript engine for React Native 0.85 and newer. Change a few lines of build config and your app runs on QuickJS instead of Hermes.
+  tagline: A drop-in JavaScript engine for React Native 0.85 and newer. One command and your app runs on QuickJS instead of Hermes.
   actions:
     - theme: brand
       text: Get started
@@ -33,9 +33,18 @@ React Native runs your JavaScript on Hermes. This replaces it with
 the current ECMAScript specification — and gives React Native the runtime and
 factory it needs to use it.
 
-It is **alpha**: setup is manual, release bundles ship as plain JavaScript
-rather than bytecode, and on iOS removing Hermes means React Native core is
-compiled from source, which makes the first build slower.
+<div style="text-align: left; max-width: 460px; margin: 1.75rem auto;">
+
+```sh
+npm install @react-native-quickjs/quickjs
+npx react-native-quickjs install
+```
+
+</div>
+
+It is **alpha**: release bundles ship as plain JavaScript rather than bytecode,
+and on iOS removing Hermes means React Native core is compiled from source,
+which makes the first build slower.
 
 [Install](https://github.com/react-native-quickjs/quickjs#install) ·
 [Known limitations](https://github.com/react-native-quickjs/quickjs#known-limitations)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-quickjs/quickjs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "QuickJS JSI runtime for React Native, built from source",
   "keywords": [
     "react-native",
@@ -32,6 +32,10 @@
     "scripts/postinstall.js",
     "scripts/react_native_quickjs_pods.rb",
     "*.podspec",
+    "bin",
+    "app.plugin.js",
+    "scripts/setup",
+    "scripts/expo",
     "!android/build",
     "!android/.cxx",
     "!**/__tests__",
@@ -59,7 +63,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.85.0"
+    "react-native": ">=0.85.0",
+    "@expo/config-plugins": "*"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^21.0.2",
@@ -76,5 +81,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bin": {
+    "react-native-quickjs": "bin/react-native-quickjs.js"
+  },
+  "peerDependenciesMeta": {
+    "@expo/config-plugins": {
+      "optional": true
+    }
   }
 }

--- a/scripts/expo/plugin.js
+++ b/scripts/expo/plugin.js
@@ -24,25 +24,26 @@ const {
 
 const { edits } = require('../setup/edits');
 
-const byLabel = (label) => edits.find((e) => e.label === label);
+const editFor = (label) => edits.find((edit) => edit.label === label);
 
-function warn(label) {
+function warnCouldNotEdit(label) {
   console.warn(
     `[@react-native-quickjs/quickjs] could not edit ${label}. ` +
       'Run `npx react-native-quickjs doctor` after prebuild.'
   );
 }
 
-/** Apply an edit to a string mod's contents. */
-function edit(label, source) {
-  const e = byLabel(label);
-  if (e.done(source)) return source;
-  const out = e.apply(source);
-  if (out == null) {
-    warn(label);
+/** Run one edit from edits.js over the contents of a string mod. */
+function addQuickJS(label, source) {
+  const edit = editFor(label);
+  if (edit.isApplied(source)) return source;
+
+  const edited = edit.addQuickJS(source);
+  if (edited == null) {
+    warnCouldNotEdit(label);
     return source;
   }
-  return out;
+  return edited;
 }
 
 // withGradleProperties hands over parsed items rather than text, so this one
@@ -60,19 +61,19 @@ function withHermesOff(config) {
 
 const withNoEngineDependency = (config) =>
   withAppBuildGradle(config, (cfg) => {
-    cfg.modResults.contents = edit('android/app/build.gradle', cfg.modResults.contents);
+    cfg.modResults.contents = addQuickJS('android/app/build.gradle', cfg.modResults.contents);
     return cfg;
   });
 
 const withAndroidFactory = (config) =>
   withMainApplication(config, (cfg) => {
-    cfg.modResults.contents = edit('MainApplication.kt', cfg.modResults.contents);
+    cfg.modResults.contents = addQuickJS('MainApplication.kt', cfg.modResults.contents);
     return cfg;
   });
 
 const withIosFactory = (config) =>
   withAppDelegate(config, (cfg) => {
-    cfg.modResults.contents = edit('AppDelegate.swift', cfg.modResults.contents);
+    cfg.modResults.contents = addQuickJS('AppDelegate.swift', cfg.modResults.contents);
     return cfg;
   });
 
@@ -84,10 +85,10 @@ const withPodfile = (config) =>
     (cfg) => {
       const file = path.join(cfg.modRequest.platformProjectRoot, 'Podfile');
       if (!fs.existsSync(file)) {
-        warn('ios/Podfile');
+        warnCouldNotEdit('ios/Podfile');
         return cfg;
       }
-      fs.writeFileSync(file, edit('ios/Podfile', fs.readFileSync(file, 'utf8')));
+      fs.writeFileSync(file, addQuickJS('ios/Podfile', fs.readFileSync(file, 'utf8')));
       return cfg;
     },
   ]);

--- a/scripts/expo/plugin.js
+++ b/scripts/expo/plugin.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The Expo config plugin. It runs the same edits as the CLI, but through
+ * Expo's mods, so a prebuild regenerates them rather than losing them.
+ *
+ *   { "expo": { "plugins": ["@react-native-quickjs/quickjs"] } }
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  withAppDelegate,
+  withDangerousMod,
+  withGradleProperties,
+  withMainApplication,
+  withAppBuildGradle,
+} = require('@expo/config-plugins');
+
+const { edits } = require('../setup/edits');
+
+const byLabel = (label) => edits.find((e) => e.label === label);
+
+function warn(label) {
+  console.warn(
+    `[@react-native-quickjs/quickjs] could not edit ${label}. ` +
+      'Run `npx react-native-quickjs doctor` after prebuild.'
+  );
+}
+
+/** Apply an edit to a string mod's contents. */
+function edit(label, source) {
+  const e = byLabel(label);
+  if (e.done(source)) return source;
+  const out = e.apply(source);
+  if (out == null) {
+    warn(label);
+    return source;
+  }
+  return out;
+}
+
+// withGradleProperties hands over parsed items rather than text, so this one
+// does not go through edits.js.
+function withHermesOff(config) {
+  return withGradleProperties(config, (cfg) => {
+    const items = cfg.modResults.filter(
+      (i) => !(i.type === 'property' && i.key === 'hermesEnabled')
+    );
+    items.push({ type: 'property', key: 'hermesEnabled', value: 'false' });
+    cfg.modResults = items;
+    return cfg;
+  });
+}
+
+const withNoEngineDependency = (config) =>
+  withAppBuildGradle(config, (cfg) => {
+    cfg.modResults.contents = edit('android/app/build.gradle', cfg.modResults.contents);
+    return cfg;
+  });
+
+const withAndroidFactory = (config) =>
+  withMainApplication(config, (cfg) => {
+    cfg.modResults.contents = edit('MainApplication.kt', cfg.modResults.contents);
+    return cfg;
+  });
+
+const withIosFactory = (config) =>
+  withAppDelegate(config, (cfg) => {
+    cfg.modResults.contents = edit('AppDelegate.swift', cfg.modResults.contents);
+    return cfg;
+  });
+
+// There is no withPodfile, so the Podfile is edited on disk after prebuild has
+// written it.
+const withPodfile = (config) =>
+  withDangerousMod(config, [
+    'ios',
+    (cfg) => {
+      const file = path.join(cfg.modRequest.platformProjectRoot, 'Podfile');
+      if (!fs.existsSync(file)) {
+        warn('ios/Podfile');
+        return cfg;
+      }
+      fs.writeFileSync(file, edit('ios/Podfile', fs.readFileSync(file, 'utf8')));
+      return cfg;
+    },
+  ]);
+
+module.exports = function withQuickJS(config) {
+  return [
+    withHermesOff,
+    withNoEngineDependency,
+    withAndroidFactory,
+    withIosFactory,
+    withPodfile,
+  ].reduce((c, mod) => mod(c), config);
+};

--- a/scripts/setup/edits.js
+++ b/scripts/setup/edits.js
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The build-config edits that move an app between Hermes and QuickJS, written
+ * once. `install` applies them, `revert` undoes them, `doctor` reports them,
+ * and the Expo plugin runs the same `apply` inside Expo's own mods.
+ *
+ * `apply` returns null when it cannot find what it expects. That is not a
+ * failure to report as an error -- the file has been customised, and the
+ * caller prints `manual` instead.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const PKG = '@react-native-quickjs/quickjs';
+const KOTLIN_IMPORT = `import com.reactnativequickjs.quickjs.QuickJSInstance`;
+const SWIFT_IMPORT = 'import ReactNativeQuickJS';
+const PODS_REQUIRE = `require_relative '../node_modules/${PKG}/scripts/react_native_quickjs_pods.rb'`;
+
+/** First file matching `name` under `dir`, breadth-first. */
+function findUnder(dir, name, depth = 7) {
+  if (depth < 0 || !fs.existsSync(dir)) return null;
+  let dirs = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'build' || entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) dirs.push(full);
+    else if (entry.name === name) return full;
+  }
+  for (const d of dirs) {
+    const hit = findUnder(d, name, depth - 1);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** Index just past the `)` closing the call whose `(` is at `open`. */
+function endOfCall(source, open) {
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/** Insert `line` after the last `import` in a Kotlin or Swift file. */
+function afterImports(source, line) {
+  if (source.includes(line)) return source;
+  const imports = [...source.matchAll(/^import .*$/gm)];
+  if (imports.length === 0) return null;
+  const last = imports[imports.length - 1];
+  const at = last.index + last[0].length;
+  return source.slice(0, at) + '\n' + line + source.slice(at);
+}
+
+const edits = [
+  {
+    label: 'android/gradle.properties',
+    locate: (root) => path.join(root, 'android', 'gradle.properties'),
+    done: (s) => /^[ \t]*hermesEnabled[ \t]*=[ \t]*false[ \t]*$/m.test(s),
+    apply: (s) =>
+      /^[ \t]*hermesEnabled[ \t]*=/m.test(s)
+        ? s.replace(/^([ \t]*hermesEnabled[ \t]*=[ \t]*).*$/m, '$1false')
+        : `${s.replace(/\s*$/, '')}\n\nhermesEnabled=false\n`,
+    revert: (s) => s.replace(/^([ \t]*hermesEnabled[ \t]*=[ \t]*).*$/m, '$1true'),
+    manual: ['Set hermesEnabled=false in android/gradle.properties'],
+  },
+
+  {
+    // The template selects Hermes or JavaScriptCore here. An app on QuickJS
+    // needs neither, and the JavaScriptCore branch is the one hermesEnabled=false
+    // would otherwise take.
+    label: 'android/app/build.gradle',
+    locate: (root) => path.join(root, 'android', 'app', 'build.gradle'),
+    done: (s) => !/hermes-android|jscFlavor/.test(s),
+    apply(s) {
+      const out = s
+        .replace(
+          /[ \t]*if \([ \t]*hermesEnabled\.toBoolean\(\)[ \t]*\) \{[\s\S]*?\n[ \t]*\}[ \t]*\n/,
+          ''
+        )
+        .replace(/[ \t]*def jscFlavor[ \t]*=.*\n/, '');
+      return out === s ? null : out;
+    },
+    revert(s) {
+      const anchor = /([ \t]*)implementation\("com\.facebook\.react:react-android"\)\n/;
+      if (!anchor.test(s)) return null;
+      return s.replace(
+        anchor,
+        (line, indent) =>
+          `${line}\n${indent}if (hermesEnabled.toBoolean()) {\n` +
+          `${indent}    implementation("com.facebook.react:hermes-android")\n` +
+          `${indent}} else {\n` +
+          `${indent}    implementation jscFlavor\n` +
+          `${indent}}\n`
+      );
+    },
+    manual: [
+      'In android/app/build.gradle, delete the dependencies block that picks',
+      'between com.facebook.react:hermes-android and jscFlavor.',
+    ],
+  },
+
+  {
+    label: 'MainApplication.kt',
+    locate: (root) => findUnder(path.join(root, 'android', 'app', 'src'), 'MainApplication.kt'),
+    done: (s) => s.includes('QuickJSInstance('),
+    apply(s) {
+      const withImport = afterImports(s, KOTLIN_IMPORT);
+      if (!withImport) return null;
+      const open = /getDefaultReactHost\(\n/.exec(withImport);
+      if (!open) return null;
+      // Added as the first argument, not the last: Kotlin named arguments may
+      // be given in any order, and the first one's indent is the only one that
+      // can be read without matching parens through a nested lambda.
+      const at = open.index + open[0].length;
+      const indent = (/^([ \t]+)\S/.exec(withImport.slice(at)) || [, '      '])[1];
+      return (
+        withImport.slice(0, at) +
+        `${indent}jsRuntimeFactory = QuickJSInstance(),\n` +
+        withImport.slice(at)
+      );
+    },
+    revert: (s) =>
+      s
+        .replace(new RegExp(`^${KOTLIN_IMPORT}\\n`, 'm'), '')
+        .replace(/^[ \t]*jsRuntimeFactory = QuickJSInstance\(\),?[ \t]*\n/m, ''),
+    manual: [
+      'In MainApplication.kt add:',
+      `  ${KOTLIN_IMPORT}`,
+      'and pass jsRuntimeFactory = QuickJSInstance() to getDefaultReactHost().',
+    ],
+  },
+
+  {
+    label: 'ios/Podfile',
+    locate: (root) => path.join(root, 'ios', 'Podfile'),
+    done: (s) => s.includes('use_quickjs!'),
+    apply(s) {
+      if (!/^[ \t]*use_react_native!\(/m.test(s)) return null;
+      let out = s.includes(PODS_REQUIRE)
+        ? s
+        : s.replace(/^(platform :ios)/m, `${PODS_REQUIRE}\n\n$1`);
+      out = out.replace(
+        /^([ \t]*)(use_react_native!\()/m,
+        `$1use_quickjs!\n\n$1$2`
+      );
+      // After React Native's own hook, which writes the value this overwrites.
+      const rn = out.indexOf('react_native_post_install(');
+      if (rn === -1) return null;
+      const close = endOfCall(out, out.indexOf('(', rn));
+      if (close === -1) return null;
+      const eol = out.indexOf('\n', close);
+      const indent = (out.slice(0, rn).match(/\n([ \t]*)$/) || [, '    '])[1];
+      return (
+        out.slice(0, eol + 1) +
+        `\n${indent}react_native_quickjs_post_install(installer)\n` +
+        out.slice(eol + 1)
+      );
+    },
+    revert: (s) =>
+      s
+        .replace(new RegExp(`^${PODS_REQUIRE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\n\\n?`, 'm'), '')
+        .replace(/^[ \t]*use_quickjs!\n\n?/m, '')
+        .replace(/\n?[ \t]*react_native_quickjs_post_install\(installer\)\n/, '\n'),
+    manual: [
+      'In ios/Podfile add, before use_react_native!:',
+      `  ${PODS_REQUIRE}`,
+      '  use_quickjs!',
+      'and react_native_quickjs_post_install(installer) after react_native_post_install.',
+    ],
+  },
+
+  {
+    label: 'AppDelegate.swift',
+    locate: (root) => findUnder(path.join(root, 'ios'), 'AppDelegate.swift'),
+    done: (s) => s.includes('jsrt_create_quickjs_factory'),
+    apply(s) {
+      const withImport = afterImports(s, SWIFT_IMPORT);
+      if (!withImport) return null;
+      const cls = /class\s+\w+\s*:\s*RCTDefaultReactNativeFactoryDelegate\s*\{/.exec(withImport);
+      if (!cls) return null;
+      const at = cls.index + cls[0].length;
+      return (
+        withImport.slice(0, at) +
+        '\n  override func createJSRuntimeFactory() -> JSRuntimeFactoryRef {\n' +
+        '    jsrt_create_quickjs_factory()\n' +
+        '  }\n' +
+        withImport.slice(at)
+      );
+    },
+    revert: (s) =>
+      s
+        .replace(new RegExp(`^${SWIFT_IMPORT}\\n`, 'm'), '')
+        .replace(
+          /\n[ \t]*override func createJSRuntimeFactory\(\)[^\n]*\{\n[ \t]*jsrt_create_quickjs_factory\(\)\n[ \t]*\}\n/,
+          '\n'
+        ),
+    manual: [
+      'In AppDelegate.swift add:',
+      `  ${SWIFT_IMPORT}`,
+      'and override createJSRuntimeFactory() to return jsrt_create_quickjs_factory().',
+    ],
+  },
+];
+
+module.exports = { edits, PKG, KOTLIN_IMPORT, SWIFT_IMPORT, PODS_REQUIRE, findUnder };

--- a/scripts/setup/edits.js
+++ b/scripts/setup/edits.js
@@ -6,11 +6,20 @@
  *
  * The build-config edits that move an app between Hermes and QuickJS, written
  * once. `install` applies them, `revert` undoes them, `doctor` reports them,
- * and the Expo plugin runs the same `apply` inside Expo's own mods.
+ * and the Expo plugin runs the same functions inside Expo's own mods.
  *
- * `apply` returns null when it cannot find what it expects. That is not a
- * failure to report as an error -- the file has been customised, and the
- * caller prints `manual` instead.
+ * Each edit is:
+ *
+ *   label         what to call the file in output
+ *   findFile      absolute path in a project, or null if the project has none
+ *   isApplied     is this file already configured for QuickJS?
+ *   addQuickJS    returns the edited source, or null (see below)
+ *   removeQuickJS the inverse
+ *   manualSteps   what to tell someone when the functions return null
+ *
+ * Returning null means "this file does not look the way I expect". That is not
+ * an error to throw -- the file has been customised, and the caller prints
+ * manualSteps instead of guessing.
  */
 
 'use strict';
@@ -18,82 +27,111 @@
 const fs = require('fs');
 const path = require('path');
 
-const PKG = '@react-native-quickjs/quickjs';
-const KOTLIN_IMPORT = `import com.reactnativequickjs.quickjs.QuickJSInstance`;
+const PACKAGE = '@react-native-quickjs/quickjs';
+const KOTLIN_IMPORT = 'import com.reactnativequickjs.quickjs.QuickJSInstance';
 const SWIFT_IMPORT = 'import ReactNativeQuickJS';
-const PODS_REQUIRE = `require_relative '../node_modules/${PKG}/scripts/react_native_quickjs_pods.rb'`;
+const PODFILE_REQUIRE = `require_relative '../node_modules/${PACKAGE}/scripts/react_native_quickjs_pods.rb'`;
 
-/** First file matching `name` under `dir`, breadth-first. */
-function findUnder(dir, name, depth = 7) {
-  if (depth < 0 || !fs.existsSync(dir)) return null;
-  let dirs = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name === 'build' || entry.name === 'node_modules') continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) dirs.push(full);
-    else if (entry.name === name) return full;
+const SKIP_DIRECTORIES = new Set(['build', 'node_modules', 'Pods']);
+
+/** The first file called `fileName` anywhere under `directory`. */
+function findFileNamed(directory, fileName, depth = 7) {
+  if (depth < 0 || !fs.existsSync(directory)) return null;
+
+  const subdirectories = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (SKIP_DIRECTORIES.has(entry.name)) continue;
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) subdirectories.push(fullPath);
+    else if (entry.name === fileName) return fullPath;
   }
-  for (const d of dirs) {
-    const hit = findUnder(d, name, depth - 1);
-    if (hit) return hit;
+
+  for (const subdirectory of subdirectories) {
+    const found = findFileNamed(subdirectory, fileName, depth - 1);
+    if (found) return found;
   }
   return null;
 }
 
-/** Index just past the `)` closing the call whose `(` is at `open`. */
-function endOfCall(source, open) {
+/** Index of the `)` that closes the call whose `(` is at `openParen`. */
+function closingParenIndex(source, openParen) {
   let depth = 0;
-  for (let i = open; i < source.length; i++) {
+  for (let i = openParen; i < source.length; i++) {
     if (source[i] === '(') depth++;
     else if (source[i] === ')' && --depth === 0) return i;
   }
   return -1;
 }
 
-/** Insert `line` after the last `import` in a Kotlin or Swift file. */
-function afterImports(source, line) {
-  if (source.includes(line)) return source;
+/** The source with `importLine` added after the last import, or null. */
+function withImportAdded(source, importLine) {
+  if (source.includes(importLine)) return source;
+
   const imports = [...source.matchAll(/^import .*$/gm)];
   if (imports.length === 0) return null;
-  const last = imports[imports.length - 1];
-  const at = last.index + last[0].length;
-  return source.slice(0, at) + '\n' + line + source.slice(at);
+
+  const lastImport = imports[imports.length - 1];
+  const insertAt = lastImport.index + lastImport[0].length;
+  return source.slice(0, insertAt) + '\n' + importLine + source.slice(insertAt);
+}
+
+/**
+ * The source without `line`, and without the blank line that followed it.
+ * A plain string match, so there is no regular expression to escape.
+ */
+function withLineRemoved(source, line) {
+  return source.includes(line + '\n\n')
+    ? source.replace(line + '\n\n', '')
+    : source.replace(line + '\n', '');
+}
+
+/** The indentation of the first line at or after `index`. */
+function indentAt(source, index, fallback) {
+  const match = /^([ \t]+)\S/.exec(source.slice(index));
+  return match ? match[1] : fallback;
 }
 
 const edits = [
   {
     label: 'android/gradle.properties',
-    locate: (root) => path.join(root, 'android', 'gradle.properties'),
-    done: (s) => /^[ \t]*hermesEnabled[ \t]*=[ \t]*false[ \t]*$/m.test(s),
-    apply: (s) =>
-      /^[ \t]*hermesEnabled[ \t]*=/m.test(s)
-        ? s.replace(/^([ \t]*hermesEnabled[ \t]*=[ \t]*).*$/m, '$1false')
-        : `${s.replace(/\s*$/, '')}\n\nhermesEnabled=false\n`,
-    revert: (s) => s.replace(/^([ \t]*hermesEnabled[ \t]*=[ \t]*).*$/m, '$1true'),
-    manual: ['Set hermesEnabled=false in android/gradle.properties'],
+    findFile: (project) => path.join(project, 'android', 'gradle.properties'),
+    isApplied: (source) => /^[ \t]*hermesEnabled[ \t]*=[ \t]*false[ \t]*$/m.test(source),
+
+    addQuickJS: (source) =>
+      /^[ \t]*hermesEnabled[ \t]*=/m.test(source)
+        ? source.replace(/^([ \t]*hermesEnabled[ \t]*=[ \t]*).*$/m, '$1false')
+        : `${source.replace(/\s*$/, '')}\n\nhermesEnabled=false\n`,
+
+    removeQuickJS: (source) =>
+      source.replace(/^([ \t]*hermesEnabled[ \t]*=[ \t]*).*$/m, '$1true'),
+
+    manualSteps: ['Set hermesEnabled=false in android/gradle.properties'],
   },
 
   {
-    // The template selects Hermes or JavaScriptCore here. An app on QuickJS
-    // needs neither, and the JavaScriptCore branch is the one hermesEnabled=false
-    // would otherwise take.
+    // The template picks Hermes or JavaScriptCore here, and hermesEnabled=false
+    // is what sends it down the JavaScriptCore branch. An app on QuickJS wants
+    // neither, so the whole block goes.
     label: 'android/app/build.gradle',
-    locate: (root) => path.join(root, 'android', 'app', 'build.gradle'),
-    done: (s) => !/hermes-android|jscFlavor/.test(s),
-    apply(s) {
-      const out = s
+    findFile: (project) => path.join(project, 'android', 'app', 'build.gradle'),
+    isApplied: (source) => !/hermes-android|jscFlavor/.test(source),
+
+    addQuickJS(source) {
+      const withoutEngines = source
         .replace(
           /[ \t]*if \([ \t]*hermesEnabled\.toBoolean\(\)[ \t]*\) \{[\s\S]*?\n[ \t]*\}[ \t]*\n/,
           ''
         )
         .replace(/[ \t]*def jscFlavor[ \t]*=.*\n/, '');
-      return out === s ? null : out;
+      return withoutEngines === source ? null : withoutEngines;
     },
-    revert(s) {
-      const anchor = /([ \t]*)implementation\("com\.facebook\.react:react-android"\)\n/;
-      if (!anchor.test(s)) return null;
-      return s.replace(
-        anchor,
+
+    removeQuickJS(source) {
+      const reactAndroid = /([ \t]*)implementation\("com\.facebook\.react:react-android"\)\n/;
+      if (!reactAndroid.test(source)) return null;
+
+      return source.replace(
+        reactAndroid,
         (line, indent) =>
           `${line}\n${indent}if (hermesEnabled.toBoolean()) {\n` +
           `${indent}    implementation("com.facebook.react:hermes-android")\n` +
@@ -102,7 +140,8 @@ const edits = [
           `${indent}}\n`
       );
     },
-    manual: [
+
+    manualSteps: [
       'In android/app/build.gradle, delete the dependencies block that picks',
       'between com.facebook.react:hermes-android and jscFlavor.',
     ],
@@ -110,29 +149,38 @@ const edits = [
 
   {
     label: 'MainApplication.kt',
-    locate: (root) => findUnder(path.join(root, 'android', 'app', 'src'), 'MainApplication.kt'),
-    done: (s) => s.includes('QuickJSInstance('),
-    apply(s) {
-      const withImport = afterImports(s, KOTLIN_IMPORT);
+    findFile: (project) =>
+      findFileNamed(path.join(project, 'android', 'app', 'src'), 'MainApplication.kt'),
+    isApplied: (source) => source.includes('QuickJSInstance('),
+
+    addQuickJS(source) {
+      const withImport = withImportAdded(source, KOTLIN_IMPORT);
       if (!withImport) return null;
-      const open = /getDefaultReactHost\(\n/.exec(withImport);
-      if (!open) return null;
-      // Added as the first argument, not the last: Kotlin named arguments may
-      // be given in any order, and the first one's indent is the only one that
-      // can be read without matching parens through a nested lambda.
-      const at = open.index + open[0].length;
-      const indent = (/^([ \t]+)\S/.exec(withImport.slice(at)) || [, '      '])[1];
+
+      const call = /getDefaultReactHost\(\n/.exec(withImport);
+      if (!call) return null;
+
+      // Added as the first argument rather than the last. Kotlin named
+      // arguments may be given in any order, and the first one's indentation
+      // is the only one readable without matching parens through the nested
+      // PackageList lambda.
+      const firstArgument = call.index + call[0].length;
+      const indent = indentAt(withImport, firstArgument, '      ');
+
       return (
-        withImport.slice(0, at) +
+        withImport.slice(0, firstArgument) +
         `${indent}jsRuntimeFactory = QuickJSInstance(),\n` +
-        withImport.slice(at)
+        withImport.slice(firstArgument)
       );
     },
-    revert: (s) =>
-      s
-        .replace(new RegExp(`^${KOTLIN_IMPORT}\\n`, 'm'), '')
-        .replace(/^[ \t]*jsRuntimeFactory = QuickJSInstance\(\),?[ \t]*\n/m, ''),
-    manual: [
+
+    removeQuickJS: (source) =>
+      withLineRemoved(source, KOTLIN_IMPORT).replace(
+        /^[ \t]*jsRuntimeFactory = QuickJSInstance\(\),?[ \t]*\n/m,
+        ''
+      ),
+
+    manualSteps: [
       'In MainApplication.kt add:',
       `  ${KOTLIN_IMPORT}`,
       'and pass jsRuntimeFactory = QuickJSInstance() to getDefaultReactHost().',
@@ -141,38 +189,50 @@ const edits = [
 
   {
     label: 'ios/Podfile',
-    locate: (root) => path.join(root, 'ios', 'Podfile'),
-    done: (s) => s.includes('use_quickjs!'),
-    apply(s) {
-      if (!/^[ \t]*use_react_native!\(/m.test(s)) return null;
-      let out = s.includes(PODS_REQUIRE)
-        ? s
-        : s.replace(/^(platform :ios)/m, `${PODS_REQUIRE}\n\n$1`);
-      out = out.replace(
-        /^([ \t]*)(use_react_native!\()/m,
-        `$1use_quickjs!\n\n$1$2`
+    findFile: (project) => path.join(project, 'ios', 'Podfile'),
+    isApplied: (source) => source.includes('use_quickjs!'),
+
+    addQuickJS(source) {
+      // Every anchor is checked before anything is written, so a Podfile this
+      // does not recognise is left alone rather than half configured.
+      const hasPlatform = /^platform :ios/m.test(source);
+      const useReactNative = /^([ \t]*)use_react_native!\(/m.exec(source);
+      const postInstall = source.indexOf('react_native_post_install(');
+      if (!hasPlatform || !useReactNative || postInstall === -1) return null;
+
+      const withRequire = source.includes(PODFILE_REQUIRE)
+        ? source
+        : source.replace(/^platform :ios/m, `${PODFILE_REQUIRE}\n\nplatform :ios`);
+
+      const withUseQuickJS = withRequire.replace(
+        /^([ \t]*)use_react_native!\(/m,
+        '$1use_quickjs!\n\n$1use_react_native!('
       );
-      // After React Native's own hook, which writes the value this overwrites.
-      const rn = out.indexOf('react_native_post_install(');
-      if (rn === -1) return null;
-      const close = endOfCall(out, out.indexOf('(', rn));
-      if (close === -1) return null;
-      const eol = out.indexOf('\n', close);
-      const indent = (out.slice(0, rn).match(/\n([ \t]*)$/) || [, '    '])[1];
+
+      // The hook must follow React Native's own, which writes the USE_HERMES
+      // build setting this overwrites.
+      const call = withUseQuickJS.indexOf('react_native_post_install(');
+      const closing = closingParenIndex(withUseQuickJS, withUseQuickJS.indexOf('(', call));
+      if (closing === -1) return null;
+
+      const endOfLine = withUseQuickJS.indexOf('\n', closing);
+      const indent = /\n([ \t]*)$/.exec(withUseQuickJS.slice(0, call));
+
       return (
-        out.slice(0, eol + 1) +
-        `\n${indent}react_native_quickjs_post_install(installer)\n` +
-        out.slice(eol + 1)
+        withUseQuickJS.slice(0, endOfLine + 1) +
+        `\n${indent ? indent[1] : '    '}react_native_quickjs_post_install(installer)\n` +
+        withUseQuickJS.slice(endOfLine + 1)
       );
     },
-    revert: (s) =>
-      s
-        .replace(new RegExp(`^${PODS_REQUIRE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\n\\n?`, 'm'), '')
+
+    removeQuickJS: (source) =>
+      withLineRemoved(source, PODFILE_REQUIRE)
         .replace(/^[ \t]*use_quickjs!\n\n?/m, '')
         .replace(/\n?[ \t]*react_native_quickjs_post_install\(installer\)\n/, '\n'),
-    manual: [
+
+    manualSteps: [
       'In ios/Podfile add, before use_react_native!:',
-      `  ${PODS_REQUIRE}`,
+      `  ${PODFILE_REQUIRE}`,
       '  use_quickjs!',
       'and react_native_quickjs_post_install(installer) after react_native_post_install.',
     ],
@@ -180,30 +240,34 @@ const edits = [
 
   {
     label: 'AppDelegate.swift',
-    locate: (root) => findUnder(path.join(root, 'ios'), 'AppDelegate.swift'),
-    done: (s) => s.includes('jsrt_create_quickjs_factory'),
-    apply(s) {
-      const withImport = afterImports(s, SWIFT_IMPORT);
+    findFile: (project) => findFileNamed(path.join(project, 'ios'), 'AppDelegate.swift'),
+    isApplied: (source) => source.includes('jsrt_create_quickjs_factory'),
+
+    addQuickJS(source) {
+      const withImport = withImportAdded(source, SWIFT_IMPORT);
       if (!withImport) return null;
-      const cls = /class\s+\w+\s*:\s*RCTDefaultReactNativeFactoryDelegate\s*\{/.exec(withImport);
-      if (!cls) return null;
-      const at = cls.index + cls[0].length;
+
+      const delegateClass =
+        /class\s+\w+\s*:\s*RCTDefaultReactNativeFactoryDelegate\s*\{/.exec(withImport);
+      if (!delegateClass) return null;
+
+      const classBody = delegateClass.index + delegateClass[0].length;
       return (
-        withImport.slice(0, at) +
+        withImport.slice(0, classBody) +
         '\n  override func createJSRuntimeFactory() -> JSRuntimeFactoryRef {\n' +
         '    jsrt_create_quickjs_factory()\n' +
         '  }\n' +
-        withImport.slice(at)
+        withImport.slice(classBody)
       );
     },
-    revert: (s) =>
-      s
-        .replace(new RegExp(`^${SWIFT_IMPORT}\\n`, 'm'), '')
-        .replace(
-          /\n[ \t]*override func createJSRuntimeFactory\(\)[^\n]*\{\n[ \t]*jsrt_create_quickjs_factory\(\)\n[ \t]*\}\n/,
-          '\n'
-        ),
-    manual: [
+
+    removeQuickJS: (source) =>
+      withLineRemoved(source, SWIFT_IMPORT).replace(
+        /\n[ \t]*override func createJSRuntimeFactory\(\)[^\n]*\{\n[ \t]*jsrt_create_quickjs_factory\(\)\n[ \t]*\}\n/,
+        '\n'
+      ),
+
+    manualSteps: [
       'In AppDelegate.swift add:',
       `  ${SWIFT_IMPORT}`,
       'and override createJSRuntimeFactory() to return jsrt_create_quickjs_factory().',
@@ -211,4 +275,4 @@ const edits = [
   },
 ];
 
-module.exports = { edits, PKG, KOTLIN_IMPORT, SWIFT_IMPORT, PODS_REQUIRE, findUnder };
+module.exports = { edits };

--- a/scripts/setup/run.js
+++ b/scripts/setup/run.js
@@ -19,7 +19,7 @@ const RED = '\x1b[31m';
 const DIM = '\x1b[2m';
 const OFF = '\x1b[0m';
 
-function root(argv) {
+function resolveProjectDirectory(argv) {
   const at = argv.indexOf('--project');
   const dir = at === -1 ? process.cwd() : path.resolve(argv[at + 1] || '.');
   if (!fs.existsSync(path.join(dir, 'package.json'))) {
@@ -30,34 +30,34 @@ function root(argv) {
 }
 
 /**
- * @param {'apply'|'revert'} mode
+ * @param {'addQuickJS'|'removeQuickJS'} direction
  * @returns {number} exit code
  */
-function change(mode, argv) {
-  const dir = root(argv);
+function applyEdits(direction, argv) {
+  const project = resolveProjectDirectory(argv);
   const dryRun = argv.includes('--dry-run');
   const manual = [];
   let changed = 0;
 
   console.log('');
   for (const edit of edits) {
-    const file = edit.locate(dir);
+    const file = edit.findFile(project);
     if (!file || !fs.existsSync(file)) {
       console.log(`  ${DIM}skipped${OFF}  ${edit.label} ${DIM}(not in this project)${OFF}`);
       continue;
     }
 
     const before = fs.readFileSync(file, 'utf8');
-    const satisfied = mode === 'apply' ? edit.done(before) : !edit.done(before);
+    const satisfied = direction === 'addQuickJS' ? edit.isApplied(before) : !edit.isApplied(before);
     if (satisfied) {
       console.log(`  ${DIM}already${OFF}  ${edit.label}`);
       continue;
     }
 
-    const after = edit[mode](before);
+    const after = edit[direction](before);
     if (after == null || after === before) {
       console.log(`  ${YELLOW}by hand${OFF}  ${edit.label}`);
-      manual.push([edit.label, edit.manual]);
+      manual.push([edit.label, edit.manualSteps]);
       continue;
     }
 
@@ -71,7 +71,7 @@ function change(mode, argv) {
     for (const line of lines) console.log(`  ${line}`);
   }
 
-  if (changed && !dryRun && mode === 'apply') {
+  if (changed && !dryRun && direction === 'addQuickJS') {
     console.log(`\nNext: cd ios && pod install\n`);
   } else {
     console.log('');
@@ -80,35 +80,35 @@ function change(mode, argv) {
 }
 
 function doctor(argv) {
-  const dir = root(argv);
-  let missing = 0;
+  const project = resolveProjectDirectory(argv);
+  let notConfigured = 0;
 
   console.log('');
   for (const edit of edits) {
-    const file = edit.locate(dir);
+    const file = edit.findFile(project);
     if (!file || !fs.existsSync(file)) {
       console.log(`  ${DIM}—${OFF}  ${edit.label} ${DIM}(not in this project)${OFF}`);
       continue;
     }
-    if (edit.done(fs.readFileSync(file, 'utf8'))) {
+    if (edit.isApplied(fs.readFileSync(file, 'utf8'))) {
       console.log(`  ${GREEN}✓${OFF}  ${edit.label}`);
     } else {
       console.log(`  ${RED}✗${OFF}  ${edit.label}`);
-      missing++;
+      notConfigured++;
     }
   }
 
   console.log(
-    missing
-      ? `\n${missing} of ${edits.length} not configured for QuickJS. ` +
+    notConfigured
+      ? `\n${notConfigured} of ${edits.length} not configured for QuickJS. ` +
           `Run: npx react-native-quickjs install\n`
       : `\nConfigured to run on QuickJS.\n`
   );
-  return missing ? 1 : 0;
+  return notConfigured ? 1 : 0;
 }
 
 module.exports = {
-  install: (argv) => change('apply', argv),
-  revert: (argv) => change('revert', argv),
+  install: (argv) => applyEdits('addQuickJS', argv),
+  revert: (argv) => applyEdits('removeQuickJS', argv),
   doctor,
 };

--- a/scripts/setup/run.js
+++ b/scripts/setup/run.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * install, revert and doctor. All three walk the same table in edits.js.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { edits } = require('./edits');
+
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const DIM = '\x1b[2m';
+const OFF = '\x1b[0m';
+
+function root(argv) {
+  const at = argv.indexOf('--project');
+  const dir = at === -1 ? process.cwd() : path.resolve(argv[at + 1] || '.');
+  if (!fs.existsSync(path.join(dir, 'package.json'))) {
+    console.error(`\nNo package.json in ${dir}. Run this from a React Native app.\n`);
+    process.exit(1);
+  }
+  return dir;
+}
+
+/**
+ * @param {'apply'|'revert'} mode
+ * @returns {number} exit code
+ */
+function change(mode, argv) {
+  const dir = root(argv);
+  const dryRun = argv.includes('--dry-run');
+  const manual = [];
+  let changed = 0;
+
+  console.log('');
+  for (const edit of edits) {
+    const file = edit.locate(dir);
+    if (!file || !fs.existsSync(file)) {
+      console.log(`  ${DIM}skipped${OFF}  ${edit.label} ${DIM}(not in this project)${OFF}`);
+      continue;
+    }
+
+    const before = fs.readFileSync(file, 'utf8');
+    const satisfied = mode === 'apply' ? edit.done(before) : !edit.done(before);
+    if (satisfied) {
+      console.log(`  ${DIM}already${OFF}  ${edit.label}`);
+      continue;
+    }
+
+    const after = edit[mode](before);
+    if (after == null || after === before) {
+      console.log(`  ${YELLOW}by hand${OFF}  ${edit.label}`);
+      manual.push([edit.label, edit.manual]);
+      continue;
+    }
+
+    if (!dryRun) fs.writeFileSync(file, after);
+    console.log(`  ${GREEN}${dryRun ? 'would' : 'wrote'}${OFF}    ${edit.label}`);
+    changed++;
+  }
+
+  for (const [label, lines] of manual) {
+    console.log(`\n${YELLOW}${label}${OFF} could not be edited automatically:`);
+    for (const line of lines) console.log(`  ${line}`);
+  }
+
+  if (changed && !dryRun && mode === 'apply') {
+    console.log(`\nNext: cd ios && pod install\n`);
+  } else {
+    console.log('');
+  }
+  return manual.length ? 1 : 0;
+}
+
+function doctor(argv) {
+  const dir = root(argv);
+  let missing = 0;
+
+  console.log('');
+  for (const edit of edits) {
+    const file = edit.locate(dir);
+    if (!file || !fs.existsSync(file)) {
+      console.log(`  ${DIM}—${OFF}  ${edit.label} ${DIM}(not in this project)${OFF}`);
+      continue;
+    }
+    if (edit.done(fs.readFileSync(file, 'utf8'))) {
+      console.log(`  ${GREEN}✓${OFF}  ${edit.label}`);
+    } else {
+      console.log(`  ${RED}✗${OFF}  ${edit.label}`);
+      missing++;
+    }
+  }
+
+  console.log(
+    missing
+      ? `\n${missing} of ${edits.length} not configured for QuickJS. ` +
+          `Run: npx react-native-quickjs install\n`
+      : `\nConfigured to run on QuickJS.\n`
+  );
+  return missing ? 1 : 0;
+}
+
+module.exports = {
+  install: (argv) => change('apply', argv),
+  revert: (argv) => change('revert', argv),
+  doctor,
+};


### PR DESCRIPTION
Adds a CLI and an Expo config plugin so an app can be moved onto QuickJS without following the README by hand.

```
npx react-native-quickjs install    configure this app to run on QuickJS
npx react-native-quickjs revert     configure it back to Hermes
npx react-native-quickjs doctor     report which parts are configured
```

For Expo, the same edits run during prebuild:

```json
{ "expo": { "plugins": ["@react-native-quickjs/quickjs"] } }
```

## How it works

`scripts/setup/edits.js` holds one table with an entry per file that has to change. Each entry says how to find the file, whether it is already configured, how to configure it, how to undo that, and what to tell someone if the file has been customised too far to edit safely.

`install`, `revert`, `doctor` and the Expo plugin all walk that table, so the CLI and a prebuild cannot drift apart.

| file | change |
| --- | --- |
| `android/gradle.properties` | `hermesEnabled=false` |
| `android/app/build.gradle` | remove the Hermes / JavaScriptCore block |
| `MainApplication.kt` | `jsRuntimeFactory = QuickJSInstance()` |
| `ios/Podfile` | `use_quickjs!` and the post-install hook |
| `AppDelegate.swift` | override `createJSRuntimeFactory()` |

When a file does not look the way the edit expects, nothing is written and the manual steps are printed instead.

## Testing

The example app was reverted to Hermes and reinstalled with the CLI, then compared against the hand-written configuration that is known to boot:

- `doctor` reports 5 of 5
- the difference is 8 insertions and 5 deletions, all cosmetic — blank lines, named-argument order, and the Podfile `require_relative` correctly pointing at `node_modules` rather than the monorepo path
- `:app:compileDebugKotlin` succeeds on the generated sources
- the generated Podfile passes `ruby -c`

The Expo plugin was loaded against a stub of `@expo/config-plugins`: all five mods register, and the two Android mods produce the expected output.

## Notes

- `@expo/config-plugins` is an optional peer dependency. It is only required when Expo loads the plugin, so non-Expo installs are unaffected.
- The plugin has not been run through a real `expo prebuild`. The CLI path is the one with evidence behind it.
- `package.json` carries the version bump to 1.0.0 that was already in the working tree. Say if it should come out of this branch.
