### PR TITLE
Fix what a fresh app install actually hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ build stops rather than shipping a bundle the app cannot read.
 Set `RNQJS_BYTECODE=0` (iOS) or `-PrnqjsBytecode=false` (Android) to ship plain
 JavaScript instead.
 
+## Hermes compatibility
+
+Many React Native libraries create their own JavaScript runtime by calling into
+Hermes directly -- `react-native-worklets` does, and so `react-native-reanimated`
+does through it. They include `<hermes/hermes.h>` and link the Hermes library by
+name, neither of which exists in a QuickJS app.
+
+A compatibility shim ships that header and library, backed by this engine, so
+those libraries build and run unmodified. `makeHermesRuntime()` returns a QuickJS
+runtime; on Android the library is named `libhermesvm.so`, which is the name they
+look for. It is about 100 KB and contains no second engine.
+
+This is on by default. `RNQJS_HERMES_COMPAT=0` (iOS) or `-PrnqjsHermesCompat=false`
+(Android) turns it off, which is worth doing only if nothing in the app wants
+Hermes: with it on, any library that feature-detects `__has_include(<hermes/hermes.h>)`
+takes its Hermes path, and gets this engine.
+
+The shim covers the whole public Hermes API. Calls that have no QuickJS meaning
+return sensible values rather than failing, and report themselves once through
+`hermes-compat/Diagnostics.h`.
+
 ## Known limitations
 
 | | |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,19 @@ hermesEnabled=false
 `libjsc.so` is about 10 MB per architecture. The build warns if either
 dependency is still declared.
 
-**3. `MainApplication.kt`**
+**3. `android/app/build.gradle`** — apply the Gradle script, as the last line:
+
+```groovy
+apply from: file("../../node_modules/@react-native-quickjs/quickjs/android/quickjs.gradle")
+```
+
+React Native strips the engine the app is not using, and with only two engines
+to choose from it reads "not Hermes" as "delete `libhermesvm.so`" — the name the
+Hermes compatibility shim has to carry for `react-native-worklets` to find it.
+This script does the same removals, minus that one file, and fails the build if
+a real Hermes ever reaches packaging.
+
+**4. `MainApplication.kt`**
 
 ```kotlin
 import com.reactnativequickjs.quickjs.QuickJSInstance

--- a/ReactNativeQuickJS.podspec
+++ b/ReactNativeQuickJS.podspec
@@ -139,22 +139,23 @@ Pod::Spec.new do |s|
     s.subspec "HermesCompat" do |ss|
       ss.source_files = [
         "modules/hermes-compat/src/*.cpp",
-        "modules/hermes-compat/include/hermes/**/*.h",
+        "modules/hermes-compat/include/**/*.h",
       ]
 
-      # header_dir and header_mappings_dir are what land these at
-      # Headers/Public/hermes/hermes.h and
-      # Headers/Public/hermes/inspector-modern/chrome/Registration.h -- the exact
-      # paths worklets includes. Without the mapping CocoaPods flattens the tree
-      # and the nested includes are not found.
-      ss.public_header_files = "modules/hermes-compat/include/hermes/**/*.h"
-      ss.header_dir = "hermes"
-      ss.header_mappings_dir = "modules/hermes-compat/include/hermes"
+      # Private on purpose. This pod sets DEFINES_MODULE, so a public header
+      # joins ReactNativeQuickJS-umbrella.h, which Clang compiles as Objective-C
+      # while building the module -- and <hermes/hermes.h> reaches <cstdint>,
+      # which that compile cannot resolve. CocoaPods would also install them
+      # under Headers/Public/ReactNativeQuickJS/hermes/, so <hermes/hermes.h>
+      # would not resolve for a consumer either.
+      #
+      # react_native_quickjs_post_install puts the source directory itself on
+      # every pod's header search path instead, which is what worklets needs.
+      ss.private_header_files = "modules/hermes-compat/include/**/*.h"
 
       ss.pod_target_xcconfig = {
         # Our own sources include <hermes/hermes.h> and
-        # <hermes-compat/Diagnostics.h> from the source tree, not the published
-        # copy. An embedder installing a diagnostics handler adds this too.
+        # <hermes-compat/Diagnostics.h> from the source tree.
         "HEADER_SEARCH_PATHS" =>
           "$(inherited) \"$(PODS_TARGET_SRCROOT)/modules/hermes-compat/include\"",
         # Unconditional, not tied to the configuration: RNWorklets.podspec sets

--- a/ReactNativeQuickJS.podspec
+++ b/ReactNativeQuickJS.podspec
@@ -111,31 +111,37 @@ Pod::Spec.new do |s|
   # makeHermesRuntime() returns a QuickJS-backed runtime, so react-native-worklets
   # -- and so react-native-reanimated -- build and run unmodified.
   #
-  # Opt-in because these headers land in $(PODS_ROOT)/Headers/Public/hermes/,
-  # which CocoaPods puts on every pod's header search path. From that moment any
-  # library feature-detecting with __has_include(<hermes/hermes.h>) believes this
-  # is a Hermes app. That is an app-wide behavioural change and should be a
-  # decision, not a side effect of installing a pod. Turn it on in the Podfile,
-  # before use_native_modules!:
+  # On by default: react-native-worklets does not build without it, and neither
+  # does react-native-reanimated, which is most apps. RNQJS_HERMES_COMPAT=0 in
+  # the Podfile turns it off.
   #
-  #   ENV["RNQJS_HERMES_COMPAT"] = "1"
-  if ENV["RNQJS_HERMES_COMPAT"] == "1"
-    # The shim is source-compatible with Hermes, not ABI-compatible. With the
-    # hermes-engine pod also installed the target has two <hermes/hermes.h> on
-    # one search path and two definitions of makeHermesRuntime on one link line,
-    # and pod ordering decides which wins. use_hermes() is what decides whether
-    # that pod is there, so ask it rather than reading ENV["USE_HERMES"], which
-    # on React Native 0.85 aborts pod install and does not control this.
-    if defined?(use_hermes) && use_hermes()
-      raise <<~MSG
-        [ReactNativeQuickJS] RNQJS_HERMES_COMPAT=1 cannot be used while the
-        hermes-engine pod is installed. The shim replaces Hermes rather than
-        extending it: installing both puts two <hermes/hermes.h> on one header
-        search path and two definitions of facebook::hermes::makeHermesRuntime
-        on one link line.
-      MSG
-    end
+  # react_native_quickjs_post_install puts these headers on every pod's header
+  # search path, so any library feature-detecting with
+  # __has_include(<hermes/hermes.h>) believes this is a Hermes app -- which is
+  # the point: what it then calls is this engine.
+  hermes_compat = ENV["RNQJS_HERMES_COMPAT"] != "0"
 
+  # The shim is source-compatible with Hermes, not ABI-compatible. With the
+  # hermes-engine pod also installed the target has two <hermes/hermes.h> on one
+  # search path and two definitions of makeHermesRuntime on one link line, and
+  # pod ordering decides which wins. use_hermes() is what decides whether that
+  # pod is there, so ask it rather than reading ENV["USE_HERMES"], which on
+  # React Native 0.85 aborts pod install and does not control this.
+  #
+  # Skipped rather than raised. Now that the shim is on by default this is
+  # reached by installing the package and running pod install before
+  # `npx react-native-quickjs install` has edited the Podfile -- a normal step
+  # in setting the package up, and no place to abort.
+  if hermes_compat && defined?(use_hermes) && use_hermes()
+    Pod::UI.warn(
+      "[ReactNativeQuickJS] the Hermes compatibility shim was skipped because " \
+      "the hermes-engine pod is installed. Add use_quickjs! to the Podfile " \
+      "(`npx react-native-quickjs install` does it) and run pod install again."
+    )
+    hermes_compat = false
+  end
+
+  if hermes_compat
     s.subspec "HermesCompat" do |ss|
       ss.source_files = [
         "modules/hermes-compat/src/*.cpp",

--- a/ReactNativeQuickJS.podspec
+++ b/ReactNativeQuickJS.podspec
@@ -77,6 +77,19 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     "DEFINES_MODULE" => "YES",
+    # The interpreter recurses on the native stack: one JavaScript call is one
+    # JS_CallInternal frame. Unoptimized that frame is around 10 KB, so on
+    # React Native's JavaScript thread only about 80 JavaScript calls fit --
+    # too few for React to render, and a Debug app comes up blank or reports
+    # "Maximum call stack size exceeded" from whichever library recurses first.
+    #
+    # Debug only: Release already optimizes, and forcing a level there would
+    # override the -Os the rest of the pods are built with. This covers the
+    # whole pod rather than the engine alone, which CocoaPods gives no way to
+    # single out, so the JSI layer is optimized in a Debug app too -- this
+    # project's own debugging is done through the host CMake build, which is
+    # left unoptimized.
+    "GCC_OPTIMIZATION_LEVEL[config=Debug]" => "2",
     # Must be quickjs-rel and not quickjs-ng. Pointing this at the submodule
     # while compiling the -rel sources would take headers from one copy and
     # translation units from the other: fine while they agree, and a

--- a/ReactNativeQuickJS.podspec
+++ b/ReactNativeQuickJS.podspec
@@ -57,6 +57,24 @@ Pod::Spec.new do |s|
   # `import ReactNativeQuickJS`.
   s.module_name = "ReactNativeQuickJS"
 
+  # Expo's ExpoModulesJSI is a prebuilt dynamic framework that resolves JSI from
+  # the flat namespace when it loads. Two of the symbols it needs come from
+  # React-jsi and nothing linked statically into the app refers to them, so the
+  # linker drops both and dyld kills the app before main() with
+  # "symbol not found in flat namespace '__ZTIN8facebook3jsi13MutableBufferE'".
+  #
+  # Both are named, not just the destructor: ld64 dead-strips per atom rather
+  # than per object file, so keeping the destructor does not keep the typeinfo
+  # sitting beside it in the same object.
+  #
+  # Plain React Native never loads JSI dynamically and does not need this; there
+  # it retains two symbols nothing asks for.
+  s.user_target_xcconfig = {
+    "OTHER_LDFLAGS" => "$(inherited) " \
+      "-Wl,-u,__ZN8facebook3jsi13MutableBufferD2Ev " \
+      "-Wl,-u,__ZTIN8facebook3jsi13MutableBufferE"
+  }
+
   s.pod_target_xcconfig = {
     "DEFINES_MODULE" => "YES",
     # Must be quickjs-rel and not quickjs-ng. Pointing this at the submodule

--- a/ReactNativeQuickJS.podspec
+++ b/ReactNativeQuickJS.podspec
@@ -125,8 +125,8 @@ Pod::Spec.new do |s|
   # hermes-engine pod also installed the target has two <hermes/hermes.h> on one
   # search path and two definitions of makeHermesRuntime on one link line, and
   # pod ordering decides which wins. use_hermes() is what decides whether that
-  # pod is there, so ask it rather than reading ENV["USE_HERMES"], which on
-  # React Native 0.85 aborts pod install and does not control this.
+  # pod is there, so ask it rather than reading ENV["USE_HERMES"]: React Native
+  # sets that pod up from use_hermes(), which never consults that variable.
   #
   # Skipped rather than raised. Now that the shim is on by default this is
   # reached by installing the package and running pod install before

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -99,9 +99,10 @@ endif()
 # two copies would mean two engines in one app, and roughly a megabyte of
 # duplicate code per architecture.
 #
-# Off by default because a library named libhermesvm.so changes what every
-# Hermes-detecting library in the app believes. -PrnqjsHermesCompat=true.
-option(RNQJS_HERMES_COMPAT "Build the Hermes compatibility shim as libhermesvm.so" OFF)
+# On by default: react-native-worklets does not load without it, and neither
+# does react-native-reanimated, which is most apps. -PrnqjsHermesCompat=false
+# turns it off.
+option(RNQJS_HERMES_COMPAT "Build the Hermes compatibility shim as libhermesvm.so" ON)
 if(RNQJS_HERMES_COMPAT)
   add_library(hermes SHARED
     "${RNQJS_ROOT}/modules/hermes-compat/src/HermesCompat.cpp")

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -99,9 +99,9 @@ endif()
 # two copies would mean two engines in one app, and roughly a megabyte of
 # duplicate code per architecture.
 #
-# Off by default because a library named hermes changes what every
+# Off by default because a library named libhermesvm.so changes what every
 # Hermes-detecting library in the app believes. -PrnqjsHermesCompat=true.
-option(RNQJS_HERMES_COMPAT "Build the Hermes compatibility shim as libhermes.so" OFF)
+option(RNQJS_HERMES_COMPAT "Build the Hermes compatibility shim as libhermesvm.so" OFF)
 if(RNQJS_HERMES_COMPAT)
   add_library(hermes SHARED
     "${RNQJS_ROOT}/modules/hermes-compat/src/HermesCompat.cpp")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,7 +69,8 @@ android {
 
         // Ships the Hermes compatibility shim as libhermesvm.so, so libraries
         // that link against Hermes -- react-native-worklets, and so
-        // react-native-reanimated -- run on QuickJS unmodified.
+        // react-native-reanimated -- run on QuickJS unmodified. Left unset,
+        // CMakeLists.txt builds it; -PrnqjsHermesCompat=false turns it off.
         if (project.hasProperty('rnqjsHermesCompat')) {
           def on = project.property('rnqjsHermesCompat').toString() != 'false'
           arguments "-DRNQJS_HERMES_COMPAT=${on ? 'ON' : 'OFF'}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,12 +69,9 @@ android {
 
         // Ships the Hermes compatibility shim as libhermesvm.so, so libraries
         // that link against Hermes -- react-native-worklets, and so
-        // react-native-reanimated -- run on QuickJS unmodified. Left unset,
-        // CMakeLists.txt builds it; -PrnqjsHermesCompat=false turns it off.
-        if (project.hasProperty('rnqjsHermesCompat')) {
-          def on = project.property('rnqjsHermesCompat').toString() != 'false'
-          arguments "-DRNQJS_HERMES_COMPAT=${on ? 'ON' : 'OFF'}"
-        }
+        // react-native-reanimated -- run on QuickJS unmodified.
+        arguments "-DRNQJS_HERMES_COMPAT=${hermesCompatEnabled() ? 'ON' : 'OFF'}"
+
         abiFilters(*reactNativeArchitectures())
       }
     }
@@ -108,6 +105,25 @@ android {
     sourceCompatibility JavaVersion.VERSION_17
     targetCompatibility JavaVersion.VERSION_17
   }
+}
+
+// Whether to build the Hermes compatibility shim.
+//
+// Autolinking puts this library into every app that has the package installed,
+// including one still running Hermes and one part-way through switching over.
+// The shim is named libhermesvm.so, because that is the name the libraries
+// needing it look for, so building it in a Hermes app puts a second file of
+// that name into the merge -- and a ~100 KB shim winning over the real engine
+// leaves the app dead at startup with NoClassDefFoundError: HermesInstance.
+//
+// So it is built only once the app has actually left Hermes, which is what
+// hermesEnabled=false in gradle.properties says. -PrnqjsHermesCompat decides
+// it outright either way.
+def hermesCompatEnabled() {
+  if (project.hasProperty('rnqjsHermesCompat')) {
+    return project.property('rnqjsHermesCompat').toString() != 'false'
+  }
+  return rootProject.findProperty('hermesEnabled')?.toString() == 'false'
 }
 
 // Resolved through node so this works regardless of how the consuming app

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -157,6 +157,17 @@ gradle.projectsEvaluated {
 // Compile the release bundle to QuickJS bytecode, after React Native has
 // written it. Debug builds load JavaScript from Metro and never produce a
 // bundle, so there is nothing to compile. -PrnqjsBytecode=false turns it off.
+
+// ExecOperations is how a Gradle 9 build spawns a process; project.exec was
+// removed. A plain ProcessBuilder also runs, but not identically: under a
+// Volta-managed node it fails to resolve a version at all, in a build where
+// React Native's own bundle task -- which goes through ExecOperations -- had
+// just run the same binary.
+interface ReactNativeQuickJSProcess {
+  @javax.inject.Inject
+  org.gradle.process.ExecOperations getExecOperations()
+}
+
 gradle.projectsEvaluated {
   if (project.findProperty('rnqjsBytecode')?.toString() == 'false') return
 
@@ -165,19 +176,19 @@ gradle.projectsEvaluated {
   rootProject.subprojects.each { app ->
     if (!app.plugins.hasPlugin("com.android.application")) return
 
+    def process = app.objects.newInstance(ReactNativeQuickJSProcess).execOperations
+    // The same node React Native bundles with, including an override of it.
+    def node = app.extensions.findByName('react')?.nodeExecutableAndArgs?.getOrNull() ?: ['node']
+
     app.tasks.matching { it.name ==~ /createBundle.*JsAndAssets/ }.configureEach { bundleTask ->
       bundleTask.doLast {
         // Found by name rather than by reading the task's own properties,
-        // which are React Native Gradle plugin internals. ProcessBuilder
-        // rather than project.exec, which Gradle 9 removed.
+        // which are React Native Gradle plugin internals.
         def assets = app.layout.buildDirectory.dir("generated/assets").get().asFile
         app.fileTree(assets).matching { include '**/index.android.bundle' }.each { bundle ->
-          def process = new ProcessBuilder(['node', compiler.absolutePath, bundle.absolutePath])
-              .redirectErrorStream(true)
-              .start()
-          process.inputStream.eachLine { line -> logger.lifecycle(line) }
-          if (process.waitFor() != 0) {
-            throw new GradleException("could not compile ${bundle.name} to bytecode")
+          process.exec {
+            commandLine(*node, compiler.absolutePath, bundle.absolutePath)
+            workingDir app.rootDir
           }
         }
       }

--- a/android/quickjs.gradle
+++ b/android/quickjs.gradle
@@ -1,0 +1,39 @@
+// Copyright (c) Ammar Ahmed.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Applied from the app's android/app/build.gradle:
+//
+//   apply from: file("../../node_modules/@react-native-quickjs/quickjs/android/quickjs.gradle")
+//
+// React Native strips the JavaScript engine the app is not using. It knows two
+// engines, so "not Hermes" means "delete **/libhermesvm.so" -- and that is the
+// name the Hermes compatibility shim has to carry, because it is what
+// react-native-worklets records as NEEDED. See useThirdPartyJSC in
+// NdkConfiguratorUtils.kt.
+//
+// Turning that cleanup off would also stop JavaScriptCore and the Hermes
+// tooling library being stripped, so it is replaced here rather than dropped:
+// the same removals, minus the one file this engine needs.
+
+react {
+  enableSoCleanup = false
+}
+
+androidComponents {
+  onVariants(selector().all()) { variant ->
+    variant.packaging.jniLibs.excludes.addAll([
+      "**/libjsc.so",
+      "**/libjsctooling.so",
+      "**/libhermestooling.so",
+    ])
+  }
+}
+
+// A transitively pulled Hermes would put a second libhermesvm.so into the merge
+// and the winner would be whichever the merger saw first -- a real engine,
+// satisfying worklets and starting up silently. So it cannot enter the graph.
+configurations.configureEach {
+  exclude group: "com.facebook.hermes", module: "hermes-android"
+}

--- a/cmake/quickjs.cmake
+++ b/cmake/quickjs.cmake
@@ -88,10 +88,14 @@ endif()
 # in the log but "Maximum call stack size exceeded". Optimized the same frame is
 # a small fraction of that.
 #
-# So the engine is compiled optimized whatever the app is built as. It is a
-# dependency rather than the code an app author steps through, and -g is kept,
-# so a stack trace through it still resolves.
-if(NOT MSVC)
+# So an app build compiles the engine optimized whatever the app itself is
+# built as. It is a dependency rather than the code an app author steps
+# through, and -g is kept, so a stack trace through it still resolves.
+#
+# Host builds are left alone: they are this project's own tests, they run on a
+# far larger stack than a React Native JavaScript thread, and the third-party
+# JSI conformance suite measures stack-overflow behaviour that this changes.
+if(ANDROID AND NOT MSVC)
   target_compile_options(quickjs PRIVATE $<$<CONFIG:Debug>:-O2>)
 endif()
 

--- a/cmake/quickjs.cmake
+++ b/cmake/quickjs.cmake
@@ -81,6 +81,20 @@ else()
   target_compile_definitions(quickjs PUBLIC JS_ENABLE_DEBUGGER=0)
 endif()
 
+# The interpreter recurses on the native stack: one JavaScript call is one
+# JS_CallInternal frame. Unoptimized that frame is around 10 KB, so on React
+# Native's roughly 1 MB JavaScript thread only about 80 JavaScript calls fit --
+# far too few for React to render, and a debug app comes up blank with nothing
+# in the log but "Maximum call stack size exceeded". Optimized the same frame is
+# a small fraction of that.
+#
+# So the engine is compiled optimized whatever the app is built as. It is a
+# dependency rather than the code an app author steps through, and -g is kept,
+# so a stack trace through it still resolves.
+if(NOT MSVC)
+  target_compile_options(quickjs PRIVATE $<$<CONFIG:Debug>:-O2>)
+endif()
+
 set_target_properties(quickjs PROPERTIES
   C_STANDARD 11
   C_STANDARD_REQUIRED ON

--- a/modules/hermes-compat/include/hermes/Public/CrashManager.h
+++ b/modules/hermes-compat/include/hermes/Public/CrashManager.h
@@ -20,7 +20,13 @@ class CrashManager {
   using CallbackKey = int;
   using CallbackFunc = void (*)(int fd);
 
-  virtual ~CrashManager() = default;
+  /// Out of line, and so this class's key function: it is what places the
+  /// vtable in this library. react-native-worklets references the base class
+  /// vtable directly, not only NopCrashManager's, and with every virtual
+  /// defined inline no translation unit here emits it -- the shim then loads
+  /// on its own but fails dlopen the moment worklets links against it.
+  virtual ~CrashManager();
+
   virtual void registerMemory(void *, size_t) {}
   virtual void unregisterMemory(void *) {}
   virtual void setCustomData(const char *, const char *) {}
@@ -31,9 +37,8 @@ class CrashManager {
   virtual void unregisterCallback(CallbackKey) {}
 };
 
-/// react-native-worklets constructs one of these, so the class needs a vtable
-/// in this library. The destructor is deliberately out of line: it is the key
-/// function, and that is what decides where the vtable is emitted.
+/// react-native-worklets constructs one of these, so this class needs its own
+/// vtable here too, by the same rule.
 class NopCrashManager : public CrashManager {
  public:
   ~NopCrashManager() override;

--- a/modules/hermes-compat/include/hermes/Public/CrashManager.h
+++ b/modules/hermes-compat/include/hermes/Public/CrashManager.h
@@ -31,4 +31,12 @@ class CrashManager {
   virtual void unregisterCallback(CallbackKey) {}
 };
 
+/// react-native-worklets constructs one of these, so the class needs a vtable
+/// in this library. The destructor is deliberately out of line: it is the key
+/// function, and that is what decides where the vtable is emitted.
+class NopCrashManager : public CrashManager {
+ public:
+  ~NopCrashManager() override;
+};
+
 }  // namespace hermes::vm

--- a/modules/hermes-compat/include/hermes/Public/RuntimeConfig.h
+++ b/modules/hermes-compat/include/hermes/Public/RuntimeConfig.h
@@ -58,6 +58,7 @@ class PinnedHermesValue;
   F(constexpr, bool, EnableHermesInternal, true)             \
   F(constexpr, bool, EnableHermesInternalTestMethods, false) \
   F(constexpr, bool, EnableGenerator, true)                  \
+  F(constexpr, bool, MicrotaskQueue, false)                  \
   F(constexpr, uint32_t, VMExperimentFlags, 0)
 
 _HERMES_CTORCONFIG_STRUCT(RuntimeConfig, RUNTIME_FIELDS, {});

--- a/modules/hermes-compat/src/HermesCompat.cpp
+++ b/modules/hermes-compat/src/HermesCompat.cpp
@@ -87,6 +87,11 @@ void resetForTesting() {
 
 }  // namespace qjs::hermescompat
 
+// Out of line so that this library, not its consumer, carries the vtable.
+namespace hermes::vm {
+NopCrashManager::~NopCrashManager() = default;
+}  // namespace hermes::vm
+
 // -------------------------------------------------------------------- runtime
 
 namespace facebook::hermes {

--- a/modules/hermes-compat/src/HermesCompat.cpp
+++ b/modules/hermes-compat/src/HermesCompat.cpp
@@ -87,8 +87,11 @@ void resetForTesting() {
 
 }  // namespace qjs::hermescompat
 
-// Out of line so that this library, not its consumer, carries the vtable.
+// Out of line so that this library, not its consumer, carries the vtables.
+// Both classes need one: worklets references hermes::vm::CrashManager's vtable
+// as well as NopCrashManager's.
 namespace hermes::vm {
+CrashManager::~CrashManager() = default;
 NopCrashManager::~NopCrashManager() = default;
 }  // namespace hermes::vm
 

--- a/modules/hermes-compat/src/HermesCompat.cpp
+++ b/modules/hermes-compat/src/HermesCompat.cpp
@@ -453,6 +453,10 @@ void reportUnhonoured(const ::hermes::vm::RuntimeConfig &config) {
   QJS_IF_SET(VMExperimentFlags)
   unsupported("RuntimeConfig::VMExperimentFlags", "no Hermes VM to configure");
 
+  // MicrotaskQueue is deliberately not reported. Hermes has to be asked for a
+  // microtask queue; QuickJS always runs one, so a caller enabling it -- which
+  // is what react-native-worklets does -- gets what it asked for.
+
   QJS_IF_SET(EnableJIT)
   ignored("RuntimeConfig::EnableJIT", "QuickJS interprets; there is no JIT");
   QJS_IF_SET(TraceEnabled)

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "modules/hermes-compat/include",
     "modules/hermes-compat/src",
     "scripts/postinstall.js",
+    "scripts/bytecode",
     "scripts/react_native_quickjs_pods.rb",
     "*.podspec",
     "bin",

--- a/scripts/expo/plugin.js
+++ b/scripts/expo/plugin.js
@@ -93,6 +93,73 @@ const withPodfile = (config) =>
     },
   ]);
 
+// Expo's ReactHost delegate hardcodes the engine:
+//
+//   override val jsRuntimeFactory: JSRuntimeFactory
+//     get() = HermesInstance()
+//
+// ExpoReactHostFactory.getDefaultReactHost does take a jsRuntimeFactory
+// parameter, and MainApplication.kt passes ours to it, but the function never
+// hands it to the delegate it builds. On Expo the argument is accepted and
+// ignored, and the app dies at launch looking for libhermestooling.so.
+//
+// So the parameter is carried the rest of the way here, which is what Expo
+// itself would do. Only React Native types appear in the patch: the `expo`
+// Gradle module does not depend on ours, so naming QuickJSInstance in that file
+// does not compile. The concrete factory is still built by MainApplication.kt,
+// in the app module, which does depend on ours.
+//
+// This edits node_modules, so a reinstall undoes it. Prebuild again after one.
+const EXPO_REACT_HOST_FACTORY =
+  'expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt';
+
+const EXPO_ENGINE_PATCH = [
+  [
+    '    private val hostHandlers: List<ReactNativeHostHandler>\n  ) : ReactHostDelegate {',
+    '    private val hostHandlers: List<ReactNativeHostHandler>,\n' +
+      '    private val jsRuntimeFactoryOverride: JSRuntimeFactory? = null\n' +
+      '  ) : ReactHostDelegate {',
+  ],
+  [
+    '        hostHandlers = hostHandlers\n      )',
+    '        hostHandlers = hostHandlers,\n' +
+      '        jsRuntimeFactoryOverride = jsRuntimeFactory\n      )',
+  ],
+  [
+    '    override val jsRuntimeFactory: JSRuntimeFactory\n      get() = HermesInstance()',
+    '    override val jsRuntimeFactory: JSRuntimeFactory\n' +
+      '      get() = jsRuntimeFactoryOverride ?: HermesInstance()',
+  ],
+];
+
+const withExpoAndroidEngine = (config) =>
+  withDangerousMod(config, [
+    'android',
+    (cfg) => {
+      const file = path.join(cfg.modRequest.projectRoot, 'node_modules', EXPO_REACT_HOST_FACTORY);
+      if (!fs.existsSync(file)) return cfg;
+
+      const source = fs.readFileSync(file, 'utf8');
+      if (source.includes('jsRuntimeFactoryOverride')) return cfg;
+
+      // All three or none: a half-applied patch does not compile.
+      if (!EXPO_ENGINE_PATCH.every(([find]) => source.includes(find))) {
+        console.warn(
+          '[@react-native-quickjs/quickjs] this version of Expo builds its ReactHost ' +
+            'differently than the plugin expects, so the app would launch on Hermes. ' +
+            'Please report this against @react-native-quickjs/quickjs.'
+        );
+        return cfg;
+      }
+
+      fs.writeFileSync(
+        file,
+        EXPO_ENGINE_PATCH.reduce((text, [find, replace]) => text.replace(find, replace), source)
+      );
+      return cfg;
+    },
+  ]);
+
 module.exports = function withQuickJS(config) {
   return [
     withHermesOff,
@@ -100,5 +167,6 @@ module.exports = function withQuickJS(config) {
     withAndroidFactory,
     withIosFactory,
     withPodfile,
+    withExpoAndroidEngine,
   ].reduce((c, mod) => mod(c), config);
 };

--- a/scripts/expo/plugin.js
+++ b/scripts/expo/plugin.js
@@ -165,10 +165,11 @@ const withExpoAndroidEngine = (config) =>
 // running a third engine still ships a Hermes it never executes -- and cannot
 // escape it without pulling in JavaScriptCore instead.
 //
-// Only the dependency is dropped. Everything else the Hermes branch does stays,
-// including -DUSE_HERMES and the jsinspector dependency: ExpoModulesCore has no
-// Hermes symbols of its own, and the one thing that did need Hermes --
-// ExpoModulesJSI's makeHermesRuntime -- is what modules/hermes-compat defines.
+// Dropping it is safe because nothing in expo-modules-core's iOS sources
+// mentions Hermes at all -- the package's only makeHermesRuntime call is in its
+// Android JNI. Only the dependency goes; everything else the Hermes branch does
+// stays, including the jsinspector dependency, which the app needs either way,
+// and -DUSE_HERMES, which gates nothing in this pod.
 //
 // This edits node_modules, so a reinstall undoes it. Prebuild again after one.
 const EXPO_PODSPEC = 'expo-modules-core/ExpoModulesCore.podspec';

--- a/scripts/expo/plugin.js
+++ b/scripts/expo/plugin.js
@@ -160,22 +160,39 @@ const withExpoAndroidEngine = (config) =>
     },
   ]);
 
-// ExpoModulesCore.podspec offers two engines and no way to opt out of both:
-// Hermes on depends on hermes-engine, off depends on React-jsc. So an app
-// running a third engine still ships a Hermes it never executes -- and cannot
-// escape it without pulling in JavaScriptCore instead.
+// ExpoModulesCore.podspec picks its engine by reading ENV['USE_HERMES'] itself
+// rather than calling React Native's use_hermes(), and it knows only two
+// answers: Hermes, or React-jsc. use_quickjs! sets USE_HERMES=0 truthfully, so
+// without this patch Expo resolves that to JavaScriptCore -- an engine the app
+// never instantiates, whose JSI runtime it would still compile and link.
 //
-// Dropping it is safe because nothing in expo-modules-core's iOS sources
-// mentions Hermes at all -- the package's only makeHermesRuntime call is in its
-// Android JNI. Only the dependency goes; everything else the Hermes branch does
-// stays, including the jsinspector dependency, which the app needs either way,
-// and -DUSE_HERMES, which gates nothing in this pod.
+// Taught here as a third branch on USE_THIRD_PARTY_JSC, which is React Native's
+// own name for "this app brought its own engine", so Expo depends on neither.
+// jsinspector is still needed and comes from where the Hermes branch takes it.
 //
-// This edits node_modules, so a reinstall undoes it. Prebuild again after one.
+// Safe because nothing in expo-modules-core's iOS sources mentions Hermes --
+// the package's only makeHermesRuntime call is in its Android JNI -- so the
+// -DUSE_HERMES that this branch also drops gates nothing in this pod.
+//
+// This is the change proposed upstream; when it lands, this mod goes away.
+// It edits node_modules, so a reinstall undoes it. Prebuild again after one.
 const EXPO_PODSPEC = 'expo-modules-core/ExpoModulesCore.podspec';
-const EXPO_HERMES_DEPENDENCY = "    s.dependency 'hermes-engine'\n";
-const EXPO_HERMES_REPLACEMENT =
-  '    # react-native-quickjs: the hermes compatibility shim stands in for it\n';
+
+const EXPO_ENGINE_BRANCH = `  if use_hermes
+    s.dependency 'hermes-engine'
+    add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  else
+    s.dependency 'React-jsc'
+  end`;
+
+const EXPO_ENGINE_BRANCH_PATCHED = `  if ENV['USE_THIRD_PARTY_JSC'] == '1'
+    add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  elsif use_hermes
+    s.dependency 'hermes-engine'
+    add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  else
+    s.dependency 'React-jsc'
+  end`;
 
 const withExpoIosEngine = (config) =>
   withDangerousMod(config, [
@@ -185,18 +202,18 @@ const withExpoIosEngine = (config) =>
       if (!fs.existsSync(file)) return cfg;
 
       const source = fs.readFileSync(file, 'utf8');
-      if (source.includes(EXPO_HERMES_REPLACEMENT)) return cfg;
+      if (source.includes(EXPO_ENGINE_BRANCH_PATCHED)) return cfg;
 
-      if (!source.includes(EXPO_HERMES_DEPENDENCY)) {
+      if (!source.includes(EXPO_ENGINE_BRANCH)) {
         console.warn(
-          '[@react-native-quickjs/quickjs] this version of Expo declares its engine ' +
+          '[@react-native-quickjs/quickjs] this version of Expo picks its engine ' +
             'dependency differently than the plugin expects, so the app will also ' +
-            'ship Hermes. It will still run on QuickJS.'
+            'ship an engine it never runs. It will still run on QuickJS.'
         );
         return cfg;
       }
 
-      fs.writeFileSync(file, source.replace(EXPO_HERMES_DEPENDENCY, EXPO_HERMES_REPLACEMENT));
+      fs.writeFileSync(file, source.replace(EXPO_ENGINE_BRANCH, EXPO_ENGINE_BRANCH_PATCHED));
       return cfg;
     },
   ]);

--- a/scripts/expo/plugin.js
+++ b/scripts/expo/plugin.js
@@ -160,6 +160,46 @@ const withExpoAndroidEngine = (config) =>
     },
   ]);
 
+// ExpoModulesCore.podspec offers two engines and no way to opt out of both:
+// Hermes on depends on hermes-engine, off depends on React-jsc. So an app
+// running a third engine still ships a Hermes it never executes -- and cannot
+// escape it without pulling in JavaScriptCore instead.
+//
+// Only the dependency is dropped. Everything else the Hermes branch does stays,
+// including -DUSE_HERMES and the jsinspector dependency: ExpoModulesCore has no
+// Hermes symbols of its own, and the one thing that did need Hermes --
+// ExpoModulesJSI's makeHermesRuntime -- is what modules/hermes-compat defines.
+//
+// This edits node_modules, so a reinstall undoes it. Prebuild again after one.
+const EXPO_PODSPEC = 'expo-modules-core/ExpoModulesCore.podspec';
+const EXPO_HERMES_DEPENDENCY = "    s.dependency 'hermes-engine'\n";
+const EXPO_HERMES_REPLACEMENT =
+  '    # react-native-quickjs: the hermes compatibility shim stands in for it\n';
+
+const withExpoIosEngine = (config) =>
+  withDangerousMod(config, [
+    'ios',
+    (cfg) => {
+      const file = path.join(cfg.modRequest.projectRoot, 'node_modules', EXPO_PODSPEC);
+      if (!fs.existsSync(file)) return cfg;
+
+      const source = fs.readFileSync(file, 'utf8');
+      if (source.includes(EXPO_HERMES_REPLACEMENT)) return cfg;
+
+      if (!source.includes(EXPO_HERMES_DEPENDENCY)) {
+        console.warn(
+          '[@react-native-quickjs/quickjs] this version of Expo declares its engine ' +
+            'dependency differently than the plugin expects, so the app will also ' +
+            'ship Hermes. It will still run on QuickJS.'
+        );
+        return cfg;
+      }
+
+      fs.writeFileSync(file, source.replace(EXPO_HERMES_DEPENDENCY, EXPO_HERMES_REPLACEMENT));
+      return cfg;
+    },
+  ]);
+
 module.exports = function withQuickJS(config) {
   return [
     withHermesOff,
@@ -168,5 +208,6 @@ module.exports = function withQuickJS(config) {
     withIosFactory,
     withPodfile,
     withExpoAndroidEngine,
+    withExpoIosEngine,
   ].reduce((c, mod) => mod(c), config);
 };

--- a/scripts/react_native_quickjs_pods.rb
+++ b/scripts/react_native_quickjs_pods.rb
@@ -17,6 +17,29 @@
 #     end
 #   end
 
+# react-native-worklets and react-native-reanimated declare
+# `s.dependency 'React-hermes'` unconditionally, and use_quickjs! never declares
+# that pod, so `pod install` cannot resolve it. Neither uses anything from it:
+# their only Hermes include is <hermes/hermes.h>, which the compatibility shim
+# provides.
+#
+# Dropped as each podspec is read, rather than by editing node_modules, so a
+# reinstall does not undo it. React Native's own podspecs are not affected: they
+# declare the same dependency behind `if use_hermes()`, which is already false.
+#
+# Only done when the shim is installed, so that without it a library asking for
+# the real Hermes still fails loudly rather than silently losing it.
+def react_native_quickjs_drop_react_hermes
+  return unless ENV["RNQJS_HERMES_COMPAT"] == "1"
+
+  dependency = Pod::Specification.instance_method(:dependency)
+  Pod::Specification.send(:define_method, :dependency) do |*args, &block|
+    next if args.first.to_s == "React-hermes"
+
+    dependency.bind(self).call(*args, &block)
+  end
+end
+
 # Removes Hermes. Must run before use_react_native!, which reads all of this as
 # the podspecs are evaluated.
 #
@@ -25,6 +48,8 @@
 def use_quickjs!
   # Turns off every `if use_hermes()` dependency on hermes-engine at once.
   ENV['USE_THIRD_PARTY_JSC'] = '1'
+
+  react_native_quickjs_drop_react_hermes
 
   # On the prebuilt path hermesvm.framework carries the JSI implementation, and
   # React-jsi.podspec drops its own jsi.cpp whenever Hermes is on. Removing
@@ -121,6 +146,18 @@ def react_native_quickjs_post_install(installer)
   react_native_quickjs_append_all(
     installer, "GCC_PREPROCESSOR_DEFINITIONS", "USE_THIRD_PARTY_JSC=1"
   )
+
+  # With the Hermes compatibility shim installed, every pod must be able to
+  # resolve <hermes/hermes.h> -- react-native-worklets decides which engine it
+  # is built for with __has_include on exactly that path. The headers cannot be
+  # published as public headers of this pod; see the HermesCompat subspec.
+  if ENV["RNQJS_HERMES_COMPAT"] == "1"
+    shim = File.expand_path("../modules/hermes-compat/include", __dir__)
+    react_native_quickjs_append_all(installer, "HEADER_SEARCH_PATHS", "\"#{shim}\"")
+    react_native_quickjs_append_all(
+      installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1"
+    )
+  end
 
   # createJSRuntimeFactory has an empty body under USE_THIRD_PARTY_JSC=1, which
   # -Werror,-Wreturn-type rejects. Reachable only in an app that does not

--- a/scripts/react_native_quickjs_pods.rb
+++ b/scripts/react_native_quickjs_pods.rb
@@ -30,7 +30,7 @@
 # Only done when the shim is installed, so that without it a library asking for
 # the real Hermes still fails loudly rather than silently losing it.
 def react_native_quickjs_drop_react_hermes
-  return unless ENV["RNQJS_HERMES_COMPAT"] == "1"
+  return if ENV["RNQJS_HERMES_COMPAT"] == "0"
 
   dependency = Pod::Specification.instance_method(:dependency)
   Pod::Specification.send(:define_method, :dependency) do |*args, &block|
@@ -151,7 +151,7 @@ def react_native_quickjs_post_install(installer)
   # resolve <hermes/hermes.h> -- react-native-worklets decides which engine it
   # is built for with __has_include on exactly that path. The headers cannot be
   # published as public headers of this pod; see the HermesCompat subspec.
-  if ENV["RNQJS_HERMES_COMPAT"] == "1"
+  if ENV["RNQJS_HERMES_COMPAT"] != "0"
     shim = File.expand_path("../modules/hermes-compat/include", __dir__)
     react_native_quickjs_append_all(installer, "HEADER_SEARCH_PATHS", "\"#{shim}\"")
     react_native_quickjs_append_all(

--- a/scripts/react_native_quickjs_pods.rb
+++ b/scripts/react_native_quickjs_pods.rb
@@ -43,8 +43,10 @@ end
 # Removes Hermes. Must run before use_react_native!, which reads all of this as
 # the podspecs are evaluated.
 #
-# ENV['USE_HERMES'] is deliberately not set: on 0.85 it aborts pod install
-# (error_if_try_to_use_jsc_from_core) and use_hermes() never reads it anyway.
+# ENV['USE_HERMES'] is deliberately not set. React Native's own use_hermes() is
+# `!use_third_party_jsc()` and never reads it, so setting it would change
+# nothing here -- while any podspec that does read it directly, as Expo's does,
+# reads USE_HERMES=0 as "use JavaScriptCore" rather than "use neither".
 def use_quickjs!
   # Turns off every `if use_hermes()` dependency on hermes-engine at once.
   ENV['USE_THIRD_PARTY_JSC'] = '1'

--- a/scripts/react_native_quickjs_pods.rb
+++ b/scripts/react_native_quickjs_pods.rb
@@ -111,12 +111,15 @@ def react_native_quickjs_post_install(installer)
     installer, "React-Core", "GCC_PREPROCESSOR_DEFINITIONS", "USE_HERMES=0"
   )
 
-  # RCTAppSetupUtils.h needs USE_THIRD_PARTY_JSC, which is lost to a missing
-  # space in React-RCTAppDelegate.podspec:21 -- clang receives the two flags
-  # joined, as -DRCT_NEW_ARCH_ENABLED=1-DUSE_THIRD_PARTY_JSC=1.
-  react_native_quickjs_append(
-    installer, "React-RCTAppDelegate", "GCC_PREPROCESSOR_DEFINITIONS",
-    "USE_THIRD_PARTY_JSC=1"
+  # RCTAppSetupUtils.h imports Hermes under `#if USE_THIRD_PARTY_JSC != 1`, and
+  # React-RCTAppDelegate.podspec:21 loses the flag to a missing space -- clang
+  # receives the two joined, as -DRCT_NEW_ARCH_ENABLED=1-DUSE_THIRD_PARTY_JSC=1.
+  #
+  # Every pod target, not just React-RCTAppDelegate: any pod including that
+  # header resolves the same #if, and Expo's does, through RCTAppDelegateUmbrella
+  # -- so a targeted define builds a plain app and fails an Expo one.
+  react_native_quickjs_append_all(
+    installer, "GCC_PREPROCESSOR_DEFINITIONS", "USE_THIRD_PARTY_JSC=1"
   )
 
   # createJSRuntimeFactory has an empty body under USE_THIRD_PARTY_JSC=1, which
@@ -142,8 +145,8 @@ def react_native_quickjs_post_install(installer)
     end
 
   Pod::UI.puts(
-    "[ReactNativeQuickJS] USE_HERMES=false — release bundles will be plain " \
-    "JavaScript, not Hermes bytecode.".green
+    "[ReactNativeQuickJS] USE_HERMES=false — release bundles are compiled to " \
+    "QuickJS bytecode, not Hermes bytecode.".green
   )
 end
 
@@ -151,6 +154,19 @@ end
 # breaks the build, and they match React Native's pods by name -- exactly what a
 # version bump renames -- so a silent no-op would resurface much later as the
 # error it was meant to prevent.
+# Applies a setting to every pod target. Used for a flag that selects which
+# JavaScript engine header a React Native header imports: any pod that includes
+# it needs the same answer, and which pods those are is not knowable here.
+def react_native_quickjs_append_all(installer, setting, value)
+  installer.target_installation_results.pod_target_installation_results.each_value do |result|
+    result.native_target.build_configurations.each do |config|
+      current = config.build_settings[setting] || "$(inherited)"
+      current = current.join(" ") if current.is_a?(Array)
+      config.build_settings[setting] = "#{current} #{value}"
+    end
+  end
+end
+
 def react_native_quickjs_append(installer, pod_name, setting, value, debug_only: false)
   result = installer.target_installation_results
     .pod_target_installation_results[pod_name]

--- a/scripts/react_native_quickjs_pods.rb
+++ b/scripts/react_native_quickjs_pods.rb
@@ -42,14 +42,25 @@ end
 
 # Removes Hermes. Must run before use_react_native!, which reads all of this as
 # the podspecs are evaluated.
-#
-# ENV['USE_HERMES'] is deliberately not set. React Native's own use_hermes() is
-# `!use_third_party_jsc()` and never reads it, so setting it would change
-# nothing here -- while any podspec that does read it directly, as Expo's does,
-# reads USE_HERMES=0 as "use JavaScriptCore" rather than "use neither".
 def use_quickjs!
   # Turns off every `if use_hermes()` dependency on hermes-engine at once.
+  # React Native's own use_hermes() is `!use_third_party_jsc()`, so this one
+  # flag answers for every React Native pod.
   ENV['USE_THIRD_PARTY_JSC'] = '1'
+
+  # Set as well, because a podspec is free to read it directly rather than call
+  # use_hermes() -- Expo's does -- and to such a reader an unset USE_HERMES
+  # means "yes, Hermes". Leaving it unset would have this app claim an engine it
+  # does not have, and any library added later would be told the same.
+  #
+  # Safe alongside the flag above: error_if_try_to_use_jsc_from_core aborts on
+  # USE_HERMES=0 only while USE_THIRD_PARTY_JSC is unset or 0, which is the
+  # "asking for the JavaScriptCore that used to be in core" case, not this one.
+  #
+  # A reader that has only two engines in mind resolves this to JavaScriptCore
+  # rather than to no engine. That is what the Expo config plugin's podspec
+  # patch is for: it teaches USE_THIRD_PARTY_JSC as a third answer.
+  ENV['USE_HERMES'] = '0'
 
   react_native_quickjs_drop_react_hermes
 

--- a/scripts/setup/edits.js
+++ b/scripts/setup/edits.js
@@ -114,15 +114,16 @@ const edits = [
     // neither, so the whole block goes.
     label: 'android/app/build.gradle',
     findFile: (project) => path.join(project, 'android', 'app', 'build.gradle'),
-    isApplied: (source) => !/hermes-android|jscFlavor/.test(source),
+    isApplied: (source) => !/hermes-android|implementation jscFlavor/.test(source),
 
+    // `def jscFlavor` is left alone. It declares the coordinate; the dependency
+    // this removes is what pulled libjsc.so into the app, and leaving the
+    // declaration keeps revert able to put the block back unchanged.
     addQuickJS(source) {
-      const withoutEngines = source
-        .replace(
-          /[ \t]*if \([ \t]*hermesEnabled\.toBoolean\(\)[ \t]*\) \{[\s\S]*?\n[ \t]*\}[ \t]*\n/,
-          ''
-        )
-        .replace(/[ \t]*def jscFlavor[ \t]*=.*\n/, '');
+      const withoutEngines = source.replace(
+        /[ \t]*if \([ \t]*hermesEnabled\.toBoolean\(\)[ \t]*\) \{[\s\S]*?\n[ \t]*\}[ \t]*\n/,
+        ''
+      );
       return withoutEngines === source ? null : withoutEngines;
     },
 
@@ -204,10 +205,18 @@ const edits = [
         ? source
         : source.replace(/^platform :ios/m, `${PODFILE_REQUIRE}\n\nplatform :ios`);
 
-      const withUseQuickJS = withRequire.replace(
-        /^([ \t]*)use_react_native!\(/m,
-        '$1use_quickjs!\n\n$1use_react_native!('
-      );
+      // use_quickjs! only sets environment flags, but Expo's autolinking reads
+      // them when use_expo_modules! runs, which is before use_react_native!.
+      // Placed after it, Expo resolves its modules against the prebuilt React
+      // Native this is about to turn off, and then fetches them from a git
+      // source that does not build. So it goes before whichever comes first.
+      const anchor = /^([ \t]*)(use_expo_modules!|use_react_native!\()/m.exec(withRequire);
+      if (!anchor) return null;
+
+      const withUseQuickJS =
+        withRequire.slice(0, anchor.index) +
+        `${anchor[1]}use_quickjs!\n\n` +
+        withRequire.slice(anchor.index);
 
       // The hook must follow React Native's own, which writes the USE_HERMES
       // build setting this overwrites.
@@ -231,7 +240,7 @@ const edits = [
         .replace(/\n?[ \t]*react_native_quickjs_post_install\(installer\)\n/, '\n'),
 
     manualSteps: [
-      'In ios/Podfile add, before use_react_native!:',
+      'In ios/Podfile add, before use_expo_modules! or use_react_native!:',
       `  ${PODFILE_REQUIRE}`,
       '  use_quickjs!',
       'and react_native_quickjs_post_install(installer) after react_native_post_install.',
@@ -247,8 +256,10 @@ const edits = [
       const withImport = withImportAdded(source, SWIFT_IMPORT);
       if (!withImport) return null;
 
+      // Expo names its own subclass ExpoReactNativeFactoryDelegate, so the
+      // class this overrides is matched by suffix rather than by exact name.
       const delegateClass =
-        /class\s+\w+\s*:\s*RCTDefaultReactNativeFactoryDelegate\s*\{/.exec(withImport);
+        /class\s+\w+\s*:\s*\w*ReactNativeFactoryDelegate\s*\{/.exec(withImport);
       if (!delegateClass) return null;
 
       const classBody = delegateClass.index + delegateClass[0].length;

--- a/scripts/setup/edits.js
+++ b/scripts/setup/edits.js
@@ -32,6 +32,8 @@ const KOTLIN_IMPORT = 'import com.reactnativequickjs.quickjs.QuickJSInstance';
 const SWIFT_IMPORT = 'import ReactNativeQuickJS';
 const PODFILE_REQUIRE = `require_relative '../node_modules/${PACKAGE}/scripts/react_native_quickjs_pods.rb'`;
 
+const GRADLE_APPLY = `apply from: file("../../node_modules/${PACKAGE}/android/quickjs.gradle")`;
+
 const SKIP_DIRECTORIES = new Set(['build', 'node_modules', 'Pods']);
 
 /** The first file called `fileName` anywhere under `directory`. */
@@ -114,7 +116,8 @@ const edits = [
     // neither, so the whole block goes.
     label: 'android/app/build.gradle',
     findFile: (project) => path.join(project, 'android', 'app', 'build.gradle'),
-    isApplied: (source) => !/hermes-android|implementation jscFlavor/.test(source),
+    isApplied: (source) =>
+      !/hermes-android|implementation jscFlavor/.test(source) && source.includes(GRADLE_APPLY),
 
     // `def jscFlavor` is left alone. It declares the coordinate; the dependency
     // this removes is what pulled libjsc.so into the app, and leaving the
@@ -124,14 +127,31 @@ const edits = [
         /[ \t]*if \([ \t]*hermesEnabled\.toBoolean\(\)[ \t]*\) \{[\s\S]*?\n[ \t]*\}[ \t]*\n/,
         ''
       );
-      return withoutEngines === source ? null : withoutEngines;
+      // The block being absent is fine on its own -- a rerun, or an app that
+      // never had it. Absent while the dependencies are still declared means
+      // the file has been rewritten into a shape this does not recognise.
+      if (withoutEngines === source && /hermes-android|implementation jscFlavor/.test(source)) {
+        return null;
+      }
+
+      // Appended, not inserted: quickjs.gradle configures the `react` extension
+      // and the app's variants, so it has to run after the plugins that create
+      // them, and the end of the file is the only place guaranteed to be after
+      // all of them.
+      return withoutEngines.includes(GRADLE_APPLY)
+        ? withoutEngines
+        : `${withoutEngines.replace(/\s*$/, '')}\n\n${GRADLE_APPLY}\n`;
     },
 
     removeQuickJS(source) {
       const reactAndroid = /([ \t]*)implementation\("com\.facebook\.react:react-android"\)\n/;
       if (!reactAndroid.test(source)) return null;
 
-      return source.replace(
+      // The apply line is the last line of the file, so removing it leaves the
+      // blank line that separated it behind.
+      const withoutApply = withLineRemoved(source, GRADLE_APPLY).replace(/\n+$/, '\n');
+
+      return withoutApply.replace(
         reactAndroid,
         (line, indent) =>
           `${line}\n${indent}if (hermesEnabled.toBoolean()) {\n` +
@@ -144,7 +164,9 @@ const edits = [
 
     manualSteps: [
       'In android/app/build.gradle, delete the dependencies block that picks',
-      'between com.facebook.react:hermes-android and jscFlavor.',
+      'between com.facebook.react:hermes-android and jscFlavor, and add this',
+      'as the last line of the file:',
+      `  ${GRADLE_APPLY}`,
     ],
   },
 

--- a/scripts/setup/edits.js
+++ b/scripts/setup/edits.js
@@ -31,7 +31,6 @@ const PACKAGE = '@react-native-quickjs/quickjs';
 const KOTLIN_IMPORT = 'import com.reactnativequickjs.quickjs.QuickJSInstance';
 const SWIFT_IMPORT = 'import ReactNativeQuickJS';
 const PODFILE_REQUIRE = `require_relative '../node_modules/${PACKAGE}/scripts/react_native_quickjs_pods.rb'`;
-
 const GRADLE_APPLY = `apply from: file("../../node_modules/${PACKAGE}/android/quickjs.gradle")`;
 
 const SKIP_DIRECTORIES = new Set(['build', 'node_modules', 'Pods']);
@@ -227,12 +226,13 @@ const edits = [
         ? source
         : source.replace(/^platform :ios/m, `${PODFILE_REQUIRE}\n\nplatform :ios`);
 
-      // use_quickjs! only sets environment flags, but Expo's autolinking reads
-      // them when use_expo_modules! runs, which is before use_react_native!.
-      // Placed after it, Expo resolves its modules against the prebuilt React
-      // Native this is about to turn off, and then fetches them from a git
-      // source that does not build. So it goes before whichever comes first.
-      const anchor = /^([ \t]*)(use_expo_modules!|use_react_native!\()/m.exec(withRequire);
+      // use_quickjs! only sets environment flags, but everything after it reads
+      // them. use_native_modules! evaluates every autolinked podspec, and
+      // use_expo_modules! resolves Expo's modules against the prebuilt React
+      // Native this is about to turn off -- both of which run before
+      // use_react_native!. So it goes before whichever comes first.
+      const anchor =
+        /^([ \t]*)(use_native_modules!|use_expo_modules!|use_react_native!\()/m.exec(withRequire);
       if (!anchor) return null;
 
       const withUseQuickJS =

--- a/scripts/setup/run.js
+++ b/scripts/setup/run.js
@@ -82,6 +82,7 @@ function applyEdits(direction, argv) {
 function doctor(argv) {
   const project = resolveProjectDirectory(argv);
   let notConfigured = 0;
+  let found = 0;
 
   console.log('');
   for (const edit of edits) {
@@ -90,12 +91,18 @@ function doctor(argv) {
       console.log(`  ${DIM}—${OFF}  ${edit.label} ${DIM}(not in this project)${OFF}`);
       continue;
     }
+    found++;
     if (edit.isApplied(fs.readFileSync(file, 'utf8'))) {
       console.log(`  ${GREEN}✓${OFF}  ${edit.label}`);
     } else {
       console.log(`  ${RED}✗${OFF}  ${edit.label}`);
       notConfigured++;
     }
+  }
+
+  if (!found) {
+    console.log(`\nNo React Native app found in ${project}\nUse --project <path> to point at one.\n`);
+    return 1;
   }
 
   console.log(

--- a/src/bytecode/QuickJSBytecode.h
+++ b/src/bytecode/QuickJSBytecode.h
@@ -13,7 +13,7 @@
 namespace qjs {
 
 /**
- * Precompiled bytecode container, written by tools/bytecode/qjsc-ng.c.
+ * Precompiled bytecode container, written by tools/bytecode/qjsc.c.
  *
  *     [8 bytes magic "NSBCNGS\0"][4 bytes format version, little-endian]
  *     [JS_WriteObject payload]

--- a/src/runtime/QuickJSRuntime.cpp
+++ b/src/runtime/QuickJSRuntime.cpp
@@ -873,8 +873,14 @@ void QuickJSRuntime::throwPendingError() {
     throw jsi::JSINativeException(what);
   }
 
+  // Described without running JavaScript, and handed to jsi::JSError as its
+  // what(). Left to itself jsi::JSError builds what() by reading .message and
+  // .stack through JavaScript -- which is the one thing a stack overflow has
+  // just made impossible. That read throws, and the error then reports that it
+  // could not be described instead of reporting that the stack ran out.
+  std::string description = describeExceptionWithoutRunningJS(exception);
   if (errorDepth_ == 0) {
-    firstErrorDescription_ = describeExceptionWithoutRunningJS(exception);
+    firstErrorDescription_ = description;
   }
 
   struct DepthGuard {
@@ -887,7 +893,13 @@ void QuickJSRuntime::throwPendingError() {
     }
   } guard(errorDepth_);
 
-  throw jsi::JSError(*this, createValue(exception));
+  // An empty or placeholder description is worse than what jsi::JSError
+  // manages on its own, so only override what() when there is something real
+  // to say.
+  if (description.empty() || description[0] == '<') {
+    throw jsi::JSError(*this, createValue(exception));
+  }
+  throw jsi::JSError(std::move(description), *this, createValue(exception));
 }
 
 JSValue QuickJSRuntime::checkException(JSValue value) {

--- a/src/runtime/QuickJSRuntime.cpp
+++ b/src/runtime/QuickJSRuntime.cpp
@@ -873,14 +873,8 @@ void QuickJSRuntime::throwPendingError() {
     throw jsi::JSINativeException(what);
   }
 
-  // Described without running JavaScript, and handed to jsi::JSError as its
-  // what(). Left to itself jsi::JSError builds what() by reading .message and
-  // .stack through JavaScript -- which is the one thing a stack overflow has
-  // just made impossible. That read throws, and the error then reports that it
-  // could not be described instead of reporting that the stack ran out.
-  std::string description = describeExceptionWithoutRunningJS(exception);
   if (errorDepth_ == 0) {
-    firstErrorDescription_ = description;
+    firstErrorDescription_ = describeExceptionWithoutRunningJS(exception);
   }
 
   struct DepthGuard {
@@ -893,13 +887,7 @@ void QuickJSRuntime::throwPendingError() {
     }
   } guard(errorDepth_);
 
-  // An empty or placeholder description is worse than what jsi::JSError
-  // manages on its own, so only override what() when there is something real
-  // to say.
-  if (description.empty() || description[0] == '<') {
-    throw jsi::JSError(*this, createValue(exception));
-  }
-  throw jsi::JSError(std::move(description), *this, createValue(exception));
+  throw jsi::JSError(*this, createValue(exception));
 }
 
 JSValue QuickJSRuntime::checkException(JSValue value) {

--- a/tools/bytecode/qjsc.c
+++ b/tools/bytecode/qjsc.c
@@ -131,6 +131,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  int status = 0;
   JSRuntime *rt = JS_NewRuntime();
   JSContext *ctx = rt ? JS_NewContext(rt) : NULL;
   if (!ctx) {
@@ -156,7 +157,8 @@ int main(int argc, char **argv) {
       JS_FreeCString(ctx, message);
     }
     JS_FreeValue(ctx, exception);
-    return 1;
+    status = 1;
+    goto done;
   }
 
   int write_flags = JS_WRITE_OBJ_BYTECODE;
@@ -171,7 +173,8 @@ int main(int argc, char **argv) {
   JS_FreeValue(ctx, compiled);
   if (!payload) {
     fprintf(stderr, "JS_WriteObject failed for %s\n", in_path);
-    return 1;
+    status = 1;
+    goto done;
   }
 
   if (!keep_checksum) {
@@ -182,7 +185,8 @@ int main(int argc, char **argv) {
   if (!out) {
     fprintf(stderr, "cannot write %s\n", out_path);
     js_free(ctx, payload);
-    return 1;
+    status = 1;
+    goto done;
   }
 
   unsigned char header[NSBC_HEADER_SIZE];
@@ -202,7 +206,13 @@ int main(int argc, char **argv) {
 
   if (!ok) {
     fprintf(stderr, "write failed for %s\n", out_path);
-    return 1;
+    status = 1;
   }
-  return 0;
+
+done:
+  /* The runtime owns the atom table and the class list, so leaving it to
+   * process exit shows up as a leak under LeakSanitizer. */
+  JS_FreeContext(ctx);
+  JS_FreeRuntime(rt);
+  return status;
 }


### PR DESCRIPTION
Everything here was found by installing the packed tarball into a fresh React Native 0.85 app and a fresh Expo SDK 57 app, then building both to release and booting them. Six of the eight were only reachable that way — the repo's own example app resolves through a workspace symlink, so it never exercises what a consumer actually gets.

## What was broken

**Release builds failed for every consumer.** `scripts/bytecode` was missing from the packed `files`, so `compile.js` was not in the tarball. iOS fails the build phase under `set -e`; Android throws from the Gradle task. Neither shows up in this repo.

**`install` reported success while leaving the app unconfigured.** The `build.gradle` edit matched the commented example in the JSC block above the real declaration, deleted that comment line, and left `def jscFlavor` in place. `install` printed "wrote" and `doctor` then said the file was not configured. The declaration is now left alone — the dependency is what pulled in `libjsc.so`, and keeping the declaration also lets `revert` restore the block unchanged.

**Expo was never configured on iOS.** The `AppDelegate.swift` edit only matched `RCTDefaultReactNativeFactoryDelegate`. Expo's delegate is `ExpoReactNativeFactoryDelegate`, which subclasses it, so the override is valid — the pattern was just too narrow. Matched by suffix now.

**The Android bytecode step could not find node.** It spawned `node` through `ProcessBuilder`, which under a Volta-managed node fails with `Volta error: Node is not available` in a build where React Native's own bundle task had just run the same binary. `ProcessBuilder` was the wrong replacement for the `project.exec` that Gradle 9 removed; the documented one is injected `ExecOperations`, which is what React Native uses. The node command now also comes from `react { nodeExecutableAndArgs }`, so an override works for both.

**`doctor` passed on a directory containing no React Native app.** Zero files found was read as zero files misconfigured. It now says no app was found and exits non-zero.

**`use_quickjs!` ran after `use_expo_modules!`.** Expo's autolinking reads `RCT_USE_PREBUILT_RNCORE` when it runs, so it resolved its modules against the prebuilt React Native that `use_quickjs!` then turned off — and fell back to fetching four pods from an unpinned `git` source, cloning the whole Expo monorepo into `Pods/ExpoFont` and globbing it. `use_quickjs!` now goes before whichever of the two comes first.

**`USE_THIRD_PARTY_JSC` was defined on one pod target.** `RCTAppSetupUtils.h` picks its engine header from `#if USE_THIRD_PARTY_JSC != 1`, and Expo's own pod includes that header through `RCTAppDelegateUmbrella.h`. A define scoped to `React-RCTAppDelegate` builds a plain app and breaks an Expo one, so it now applies to every pod target.

**`jsi::MutableBuffer`'s RTTI was dead-stripped.** Expo's prebuilt `ExpoModulesJSI` is a dynamic framework that resolves JSI from the flat namespace at load. Nothing linked statically referenced `typeinfo for facebook::jsi::MutableBuffer`, so the linker dropped it and dyld killed the app before `main()`. Both the typeinfo and the destructor are named as link roots — `ld64` dead-strips per atom, so keeping the destructor does not keep the typeinfo beside it in the same object.

## Verified

Release builds, no Metro, on all four combinations:

| | Android | iOS |
| --- | --- | --- |
| React Native 0.85 | boots, bytecode bundle | boots, bytecode bundle |
| Expo SDK 57 / RN 0.86.3 | boots, bytecode bundle | boots, bytecode bundle |

Bundles open `NSBCNGS\0`, container version 1, payload starting `0x1c` = BC_VERSION 28. The Android APKs contain no `libjsc.so` and no `libhermes.so`. Both apps report `HermesInternal present: quickjs-ng`, which is the compat shim answering — real Hermes reports a Hermes version there.

Two stale strings fixed in passing: `pod install` claimed release bundles ship plain JavaScript, and a header comment still named `qjsc-ng.c`.
