### PR TITLE
Add the Hermes compatibility shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,4 @@ add_subdirectory(tests)
 # Added after tests/ on purpose: tests/CMakeLists.txt is where googletest is
 # fetched, and modules/cdp registers its own test against GTest::gtest.
 add_subdirectory(modules/cdp)
+add_subdirectory(modules/hermes-compat)

--- a/ReactNativeQuickJS.podspec
+++ b/ReactNativeQuickJS.podspec
@@ -87,6 +87,68 @@ Pod::Spec.new do |s|
   # quickjs builds warning-clean upstream, but not under React Native's flags.
   s.compiler_flags = "-Wno-unused-parameter -Wno-unused-variable -Wno-sign-compare -Wno-implicit-fallthrough"
 
+  # The Hermes compatibility shim, opt-in.
+  #
+  # modules/hermes-compat publishes a source-compatible <hermes/hermes.h> whose
+  # makeHermesRuntime() returns a QuickJS-backed runtime, so react-native-worklets
+  # -- and so react-native-reanimated -- build and run unmodified.
+  #
+  # Opt-in because these headers land in $(PODS_ROOT)/Headers/Public/hermes/,
+  # which CocoaPods puts on every pod's header search path. From that moment any
+  # library feature-detecting with __has_include(<hermes/hermes.h>) believes this
+  # is a Hermes app. That is an app-wide behavioural change and should be a
+  # decision, not a side effect of installing a pod. Turn it on in the Podfile,
+  # before use_native_modules!:
+  #
+  #   ENV["RNQJS_HERMES_COMPAT"] = "1"
+  if ENV["RNQJS_HERMES_COMPAT"] == "1"
+    # The shim is source-compatible with Hermes, not ABI-compatible. With the
+    # hermes-engine pod also installed the target has two <hermes/hermes.h> on
+    # one search path and two definitions of makeHermesRuntime on one link line,
+    # and pod ordering decides which wins. use_hermes() is what decides whether
+    # that pod is there, so ask it rather than reading ENV["USE_HERMES"], which
+    # on React Native 0.85 aborts pod install and does not control this.
+    if defined?(use_hermes) && use_hermes()
+      raise <<~MSG
+        [ReactNativeQuickJS] RNQJS_HERMES_COMPAT=1 cannot be used while the
+        hermes-engine pod is installed. The shim replaces Hermes rather than
+        extending it: installing both puts two <hermes/hermes.h> on one header
+        search path and two definitions of facebook::hermes::makeHermesRuntime
+        on one link line.
+      MSG
+    end
+
+    s.subspec "HermesCompat" do |ss|
+      ss.source_files = [
+        "modules/hermes-compat/src/*.cpp",
+        "modules/hermes-compat/include/hermes/**/*.h",
+      ]
+
+      # header_dir and header_mappings_dir are what land these at
+      # Headers/Public/hermes/hermes.h and
+      # Headers/Public/hermes/inspector-modern/chrome/Registration.h -- the exact
+      # paths worklets includes. Without the mapping CocoaPods flattens the tree
+      # and the nested includes are not found.
+      ss.public_header_files = "modules/hermes-compat/include/hermes/**/*.h"
+      ss.header_dir = "hermes"
+      ss.header_mappings_dir = "modules/hermes-compat/include/hermes"
+
+      ss.pod_target_xcconfig = {
+        # Our own sources include <hermes/hermes.h> and
+        # <hermes-compat/Diagnostics.h> from the source tree, not the published
+        # copy. An embedder installing a diagnostics handler adds this too.
+        "HEADER_SEARCH_PATHS" =>
+          "$(inherited) \"$(PODS_TARGET_SRCROOT)/modules/hermes-compat/include\"",
+        # Unconditional, not tied to the configuration: RNWorklets.podspec sets
+        # HERMES_ENABLE_DEBUGGER=1 for every Debug build regardless of
+        # USE_HERMES, so a Debug worklets references enableDebugging and needs
+        # it defined. Safe only because no member declaration in the shim's
+        # headers is conditional on this macro.
+        "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) HERMES_ENABLE_DEBUGGER=1",
+      }
+    end
+  end
+
   install_modules_dependencies(s)
 
   s.dependency "React-jsi"

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -85,3 +85,49 @@ if(RNQJS_ENABLE_CDP)
     "${CDP_DIR}" "${CDP_DIR}/react")
   target_compile_definitions(quickjsinstancejni PRIVATE RNQJS_ENABLE_CDP=1)
 endif()
+
+# The Hermes compatibility shim, opt-in, built as libhermesvm.so.
+#
+# react-native-worklets picks its engine at compile time and links React
+# Native's imported `hermes` target, so what it records as NEEDED is the file
+# that target points at. On React Native 0.85 that is libhermesvm.so, not
+# libhermes.so -- see ReactAndroid/src/main/jni/first-party/hermes/CMakeLists.txt.
+# Giving it a library of that name, whose makeHermesRuntime returns a QuickJS
+# runtime, is what lets it run here unmodified.
+#
+# It links libquickjsinstancejni.so rather than compiling the engine again:
+# two copies would mean two engines in one app, and roughly a megabyte of
+# duplicate code per architecture.
+#
+# Off by default because a library named hermes changes what every
+# Hermes-detecting library in the app believes. -PrnqjsHermesCompat=true.
+option(RNQJS_HERMES_COMPAT "Build the Hermes compatibility shim as libhermes.so" OFF)
+if(RNQJS_HERMES_COMPAT)
+  add_library(hermes SHARED
+    "${RNQJS_ROOT}/modules/hermes-compat/src/HermesCompat.cpp")
+
+  target_include_directories(hermes PUBLIC
+    "${RNQJS_ROOT}/modules/hermes-compat/include")
+  target_include_directories(hermes PRIVATE
+    "${RNQJS_ROOT}/src/bytecode"
+    "${RNQJS_ROOT}/src/module"
+    "${RNQJS_ROOT}/src/runtime")
+
+  # Unconditional, matching the podspec: RNWorklets defines this for every
+  # Debug build, so enableDebugging must exist whatever this library was
+  # compiled with. Safe only because no member declaration in the shim's
+  # headers is conditional on it.
+  target_compile_definitions(hermes PRIVATE HERMES_ENABLE_DEBUGGER=1)
+
+  target_link_libraries(hermes
+    quickjsinstancejni
+    ReactAndroid::jsi
+    android
+    log
+  )
+
+  set_target_properties(hermes PROPERTIES
+    OUTPUT_NAME hermesvm
+    POSITION_INDEPENDENT_CODE ON
+  )
+endif()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,6 +66,14 @@ android {
           def on = project.property('rnqjsEnableCdp').toString() != 'false'
           arguments "-DRNQJS_ENABLE_CDP=${on ? 'ON' : 'OFF'}"
         }
+
+        // Ships the Hermes compatibility shim as libhermesvm.so, so libraries
+        // that link against Hermes -- react-native-worklets, and so
+        // react-native-reanimated -- run on QuickJS unmodified.
+        if (project.hasProperty('rnqjsHermesCompat')) {
+          def on = project.property('rnqjsHermesCompat').toString() != 'false'
+          arguments "-DRNQJS_HERMES_COMPAT=${on ? 'ON' : 'OFF'}"
+        }
         abiFilters(*reactNativeArchitectures())
       }
     }

--- a/modules/hermes-compat/CMakeLists.txt
+++ b/modules/hermes-compat/CMakeLists.txt
@@ -18,3 +18,10 @@ set_target_properties(hermes_compat PROPERTIES
   CXX_STANDARD_REQUIRED ON
   POSITION_INDEPENDENT_CODE ON
 )
+
+if(TARGET GTest::gtest)
+  add_executable(hermes_compat_tests test/hermes_compat_test.cpp)
+  target_link_libraries(hermes_compat_tests
+    PRIVATE hermes_compat GTest::gtest GTest::gtest_main)
+  add_test(NAME hermes_compat COMMAND hermes_compat_tests)
+endif()

--- a/modules/hermes-compat/CMakeLists.txt
+++ b/modules/hermes-compat/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Ammar Ahmed.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# The Hermes compatibility shim. See README.md.
+
+add_library(hermes_compat STATIC src/HermesCompat.cpp)
+
+# PUBLIC: a consumer writing `#include <hermes/hermes.h>` must resolve it here,
+# and must resolve it BEFORE any real Hermes headers.
+target_include_directories(hermes_compat PUBLIC include)
+
+target_link_libraries(hermes_compat PUBLIC quickjs_jsi)
+
+set_target_properties(hermes_compat PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
+  POSITION_INDEPENDENT_CODE ON
+)

--- a/modules/hermes-compat/README.md
+++ b/modules/hermes-compat/README.md
@@ -37,10 +37,14 @@ may not. Consumers are compiled separately from this shim with flags it does
 not control, so a conditional virtual shifts every later vtable slot and the
 failure is a silent call to the wrong function.
 
-**Do not fill in `hermes::vm::RuntimeConfig`.** It is empty so that code
-configuring the VM fails to compile with the field named, rather than having
-settings -- several of them security settings -- silently dropped. If a real
-consumer needs one field, add that one and wire it to QuickJS.
+**A new `RuntimeConfig` field is not honoured until it is reported.**
+`RuntimeConfig` and `GCConfig` carry Hermes's full field set and its defaults,
+so code configuring the VM compiles. Nothing configures QuickJS, so
+`makeHermesRuntime` compares what it is handed against those defaults and names
+every field it cannot honour -- unsupported where the field changes what
+JavaScript may do, such as `EnableEval`, ignored where nothing observable
+depends on it. Add a field to `reportUnhonoured` in the same commit that adds
+it to the list, or it will be dropped in silence.
 
 ## Not ABI compatibility
 

--- a/modules/hermes-compat/README.md
+++ b/modules/hermes-compat/README.md
@@ -1,0 +1,48 @@
+# hermes-compat
+
+A source-compatible `<hermes/hermes.h>` whose `makeHermesRuntime()` returns a
+QuickJS-backed runtime, so React Native libraries that create their own Hermes
+runtime build and run unmodified.
+
+## Why
+
+`react-native-worklets`, and so `react-native-reanimated`, does not use the
+app's JavaScript runtime. It creates its own and picks the engine at compile
+time from `__has_include(<hermes/hermes.h>)`, with no third branch. Expo's
+`ExpoModulesJSI` calls `facebook::hermes::makeHermesRuntime` directly. Without
+this shim neither can be used on QuickJS at all.
+
+## What you get
+
+`makeHermesRuntime()` returns a real `jsi::Runtime`. Every JSI method is
+forwarded by `jsi::RuntimeDecorator`, so a change to JSI is a compile error
+here rather than a silent divergence.
+
+Everything Hermes-specific is either implemented against a genuine QuickJS
+capability -- `watchTimeLimit` uses the engine's interrupt handler,
+`getUniqueID` uses the object address -- or reports through
+`hermes-compat/Diagnostics.h` before returning a value chosen to fail safely.
+`getVMRuntimeUnsafe()` returns null rather than a `JSContext *` a caller would
+cast to `hermes::vm::Runtime`; `makeThreadSafeHermesRuntime()` returns null
+rather than an unlocked runtime.
+
+Reports are one per API, to stderr or logcat. Install your own with
+`qjs::hermescompat::setHandler`. Nothing aborts: strictness is yours to choose.
+
+## Two rules when editing
+
+**No member declaration in `include/hermes/**` may be conditional on a
+preprocessor macro.** Free functions may be; virtual functions and data members
+may not. Consumers are compiled separately from this shim with flags it does
+not control, so a conditional virtual shifts every later vtable slot and the
+failure is a silent call to the wrong function.
+
+**Do not fill in `hermes::vm::RuntimeConfig`.** It is empty so that code
+configuring the VM fails to compile with the field named, rather than having
+settings -- several of them security settings -- silently dropped. If a real
+consumer needs one field, add that one and wire it to QuickJS.
+
+## Not ABI compatibility
+
+These headers must never be on the include path while a real `libhermes` is on
+the link line.

--- a/modules/hermes-compat/README.md
+++ b/modules/hermes-compat/README.md
@@ -1,52 +1,25 @@
 # hermes-compat
 
-A source-compatible `<hermes/hermes.h>` whose `makeHermesRuntime()` returns a
-QuickJS-backed runtime, so React Native libraries that create their own Hermes
-runtime build and run unmodified.
+A source-compatible `<hermes/hermes.h>` whose `makeHermesRuntime()` returns a QuickJS-backed runtime, so React Native libraries that create their own Hermes runtime build and run unmodified.
 
 ## Why
 
-`react-native-worklets`, and so `react-native-reanimated`, does not use the
-app's JavaScript runtime. It creates its own and picks the engine at compile
-time from `__has_include(<hermes/hermes.h>)`, with no third branch. Expo's
-`ExpoModulesJSI` calls `facebook::hermes::makeHermesRuntime` directly. Without
-this shim neither can be used on QuickJS at all.
+`react-native-worklets`, and so `react-native-reanimated`, does not use the app's JavaScript runtime. It creates its own and picks the engine at compile time from `__has_include(<hermes/hermes.h>)`, with no third branch. Expo's `ExpoModulesJSI` calls `facebook::hermes::makeHermesRuntime` directly. Without this shim neither can be used on QuickJS at all.
 
 ## What you get
 
-`makeHermesRuntime()` returns a real `jsi::Runtime`. Every JSI method is
-forwarded by `jsi::RuntimeDecorator`, so a change to JSI is a compile error
-here rather than a silent divergence.
+`makeHermesRuntime()` returns a real `jsi::Runtime`. Every JSI method is forwarded by `jsi::RuntimeDecorator`, so a change to JSI is a compile error here rather than a silent divergence.
 
-Everything Hermes-specific is either implemented against a genuine QuickJS
-capability -- `watchTimeLimit` uses the engine's interrupt handler,
-`getUniqueID` uses the object address -- or reports through
-`hermes-compat/Diagnostics.h` before returning a value chosen to fail safely.
-`getVMRuntimeUnsafe()` returns null rather than a `JSContext *` a caller would
-cast to `hermes::vm::Runtime`; `makeThreadSafeHermesRuntime()` returns null
-rather than an unlocked runtime.
+Everything Hermes-specific is either implemented against a genuine QuickJS capability -- `watchTimeLimit` uses the engine's interrupt handler, `getUniqueID` uses the object address -- or reports through `hermes-compat/Diagnostics.h` before returning a value chosen to fail safely. `getVMRuntimeUnsafe()` returns null rather than a `JSContext *` a caller would cast to `hermes::vm::Runtime`; `makeThreadSafeHermesRuntime()` returns null rather than an unlocked runtime.
 
-Reports are one per API, to stderr or logcat. Install your own with
-`qjs::hermescompat::setHandler`. Nothing aborts: strictness is yours to choose.
+Reports are one per API, to stderr or logcat. Install your own with `qjs::hermescompat::setHandler`. Nothing aborts: strictness is yours to choose.
 
 ## Two rules when editing
 
-**No member declaration in `include/hermes/**` may be conditional on a
-preprocessor macro.** Free functions may be; virtual functions and data members
-may not. Consumers are compiled separately from this shim with flags it does
-not control, so a conditional virtual shifts every later vtable slot and the
-failure is a silent call to the wrong function.
+**No member declaration in `include/hermes/**` may be conditional on a preprocessor macro.** Free functions may be; virtual functions and data members may not. Consumers are compiled separately from this shim with flags it does not control, so a conditional virtual shifts every later vtable slot and the failure is a silent call to the wrong function.
 
-**A new `RuntimeConfig` field is not honoured until it is reported.**
-`RuntimeConfig` and `GCConfig` carry Hermes's full field set and its defaults,
-so code configuring the VM compiles. Nothing configures QuickJS, so
-`makeHermesRuntime` compares what it is handed against those defaults and names
-every field it cannot honour -- unsupported where the field changes what
-JavaScript may do, such as `EnableEval`, ignored where nothing observable
-depends on it. Add a field to `reportUnhonoured` in the same commit that adds
-it to the list, or it will be dropped in silence.
+**A new `RuntimeConfig` field is not honoured until it is reported.** `RuntimeConfig` and `GCConfig` carry Hermes's full field set and its defaults, so code configuring the VM compiles. Nothing configures QuickJS, so `makeHermesRuntime` compares what it is handed against those defaults and names every field it cannot honour -- unsupported where the field changes what JavaScript may do, such as `EnableEval`, ignored where nothing observable depends on it. Add a field to `reportUnhonoured` in the same commit that adds it to the list, or it will be dropped in silence.
 
 ## Not ABI compatibility
 
-These headers must never be on the include path while a real `libhermes` is on
-the link line.
+These headers must never be on the include path while a real `libhermes` is on the link line.

--- a/modules/hermes-compat/include/hermes-compat/Diagnostics.h
+++ b/modules/hermes-compat/include/hermes-compat/Diagnostics.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace qjs::hermescompat {
+
+enum class Severity : uint8_t {
+  Degraded,     ///< Ran, but not the way Hermes would have.
+  Ignored,      ///< Did nothing, and nothing observable depended on it.
+  Unsupported,  ///< Could not be honoured; the result is a safe stand-in.
+};
+
+using Handler =
+    std::function<void(Severity, const char *api, const char *detail)>;
+
+/// Replaces the default handler, which writes to stderr, or to logcat on
+/// Android. Nothing aborts: how strict to be is the embedder's call.
+void setHandler(Handler handler);
+
+/// Reports the first time each `api` is seen, so a call in a loop says it
+/// once. Called by the shim; `api` is always a literal.
+void report(Severity severity, const char *api, const char *detail);
+
+}  // namespace qjs::hermescompat

--- a/modules/hermes-compat/include/hermes-compat/Diagnostics.h
+++ b/modules/hermes-compat/include/hermes-compat/Diagnostics.h
@@ -29,4 +29,7 @@ void setHandler(Handler handler);
 /// once. Called by the shim; `api` is always a literal.
 void report(Severity severity, const char *api, const char *detail);
 
+/// Forgets which APIs have reported, so the next call to each reports again.
+void resetForTesting();
+
 }  // namespace qjs::hermescompat

--- a/modules/hermes-compat/include/hermes/DebuggerAPI.h
+++ b/modules/hermes-compat/include/hermes/DebuggerAPI.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::hermes::debugger {
+
+// Named so that IHermes::getDebugger has a complete return type. Hermes's
+// debugger is expressed in bytecode offsets and has no QuickJS meaning;
+// debugging here goes through jsinspector-modern and modules/cdp instead.
+class Debugger {
+ public:
+  Debugger() = default;
+};
+
+}  // namespace facebook::hermes::debugger

--- a/modules/hermes-compat/include/hermes/Public/CrashManager.h
+++ b/modules/hermes-compat/include/hermes/Public/CrashManager.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace hermes::vm {
+
+/// Named so that code passing a crash manager compiles. QuickJS installs no
+/// crash handlers, so a registered callback is never invoked.
+class CrashManager {
+ public:
+  using CallbackKey = int;
+  using CallbackFunc = void (*)(int fd);
+
+  virtual ~CrashManager() = default;
+  virtual void registerMemory(void *, size_t) {}
+  virtual void unregisterMemory(void *) {}
+  virtual void setCustomData(const char *, const char *) {}
+  virtual void removeCustomData(const char *) {}
+  virtual CallbackKey registerCallback(CallbackFunc) {
+    return 0;
+  }
+  virtual void unregisterCallback(CallbackKey) {}
+};
+
+}  // namespace hermes::vm

--- a/modules/hermes-compat/include/hermes/Public/CtorConfig.h
+++ b/modules/hermes-compat/include/hermes/Public/CtorConfig.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * Generates a config class and its Builder from a field list, the way Hermes
+ * does. Same shape as upstream -- getX, getDefaultX, rebuild, Builder::withX,
+ * hasX, update, build -- so code written against Hermes compiles unchanged.
+ */
+
+#pragma once
+
+#include <utility>
+
+#define _HERMES_CTORCONFIG_FIELD(CX, TYPE, NAME, ...) TYPE NAME##_{__VA_ARGS__};
+#define _HERMES_CTORCONFIG_EXPLICIT(CX, TYPE, NAME, ...) \
+  bool NAME##Explicit_{false};
+
+#define _HERMES_CTORCONFIG_GETTER(CX, TYPE, NAME, ...) \
+  inline TYPE get##NAME() const {                      \
+    return NAME##_;                                    \
+  }                                                    \
+  static CX TYPE getDefault##NAME() {                  \
+    using TypeAsSingleToken = TYPE;                    \
+    return TypeAsSingleToken{__VA_ARGS__};             \
+  }
+
+#define _HERMES_CTORCONFIG_SETTER(CX, TYPE, NAME, ...) \
+  inline auto with##NAME(TYPE NAME)->decltype(*this) { \
+    config_.NAME##_ = std::move(NAME);                 \
+    NAME##Explicit_ = true;                            \
+    return *this;                                      \
+  }                                                    \
+  bool has##NAME() const {                             \
+    return NAME##Explicit_;                            \
+  }
+
+#define _HERMES_CTORCONFIG_UPDATE(CX, TYPE, NAME, ...) \
+  if (newConfig.has##NAME()) with##NAME(newConfig.config_.get##NAME());
+
+#define _HERMES_CTORCONFIG_STRUCT(NAME, FIELDS, BUILD_BODY)                    \
+  class NAME {                                                                 \
+    FIELDS(_HERMES_CTORCONFIG_FIELD)                                           \
+                                                                               \
+   public:                                                                     \
+    class Builder;                                                             \
+    friend Builder;                                                            \
+    FIELDS(_HERMES_CTORCONFIG_GETTER)                                          \
+    inline Builder rebuild() const;                                            \
+                                                                               \
+   private:                                                                    \
+    inline void doBuild(const Builder &builder);                               \
+  };                                                                           \
+                                                                               \
+  class NAME::Builder {                                                        \
+    NAME config_;                                                              \
+    FIELDS(_HERMES_CTORCONFIG_EXPLICIT)                                        \
+                                                                               \
+   public:                                                                     \
+    Builder() = default;                                                       \
+    explicit Builder(const NAME &config) : config_(config) {}                  \
+    inline const NAME build() {                                                \
+      config_.doBuild(*this);                                                  \
+      return config_;                                                          \
+    }                                                                          \
+    inline Builder update(const NAME::Builder &newConfig);                     \
+    FIELDS(_HERMES_CTORCONFIG_SETTER)                                          \
+  };                                                                           \
+                                                                               \
+  inline NAME::Builder NAME::rebuild() const {                                 \
+    return Builder(*this);                                                     \
+  }                                                                            \
+                                                                               \
+  inline NAME::Builder NAME::Builder::update(const NAME::Builder &newConfig) { \
+    FIELDS(_HERMES_CTORCONFIG_UPDATE)                                          \
+    return *this;                                                              \
+  }                                                                            \
+                                                                               \
+  inline void NAME::doBuild(const NAME::Builder &builder) {                    \
+    (void)builder;                                                             \
+    BUILD_BODY                                                                 \
+  }
+
+/// Marks a field whose default is not constexpr, as upstream does.
+#define HERMES_NON_CONSTEXPR

--- a/modules/hermes-compat/include/hermes/Public/GCConfig.h
+++ b/modules/hermes-compat/include/hermes/Public/GCConfig.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <hermes/Public/CtorConfig.h>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <string>
+
+namespace hermes::vm {
+
+using gcheapsize_t = uint32_t;
+
+enum ReleaseUnused {
+  kReleaseUnusedNone = 0,
+  kReleaseUnusedOld,
+  kReleaseUnusedYoungOnFull,
+  kReleaseUnusedYoungAlways
+};
+
+enum class GCEventKind {
+  CollectionStart,
+  CollectionEnd,
+};
+
+/// Hermes fills this in for its analytics callback. QuickJS never emits one,
+/// so the fields exist to be named, not to be populated.
+struct GCAnalyticsEvent {
+  std::string runtimeDescription;
+  std::string gcKind;
+  std::string collectionType;
+  std::string cause;
+  std::chrono::milliseconds duration{0};
+  std::chrono::milliseconds cpuDuration{0};
+  uint64_t allocated{0};
+  uint64_t size{0};
+  uint64_t external{0};
+  uint64_t survivalRatio{0};
+};
+
+#define GC_TRIPWIRE_FIELDS(F) \
+  F(constexpr, gcheapsize_t, Limit, std::numeric_limits<gcheapsize_t>::max())
+
+_HERMES_CTORCONFIG_STRUCT(GCTripwireConfig, GC_TRIPWIRE_FIELDS, {});
+
+#define GC_HANDLESAN_FIELDS(F)            \
+  F(constexpr, double, SanitizeRate, 0.0) \
+  F(constexpr, int64_t, RandomSeed, -1)
+
+_HERMES_CTORCONFIG_STRUCT(GCSanitizeConfig, GC_HANDLESAN_FIELDS, {});
+
+#define GC_FIELDS(F)                                                      \
+  F(constexpr, gcheapsize_t, MinHeapSize, 0)                              \
+  F(constexpr, gcheapsize_t, InitHeapSize, 32 << 20)                      \
+  F(constexpr, gcheapsize_t, MaxHeapSize, 3u << 30)                       \
+  F(constexpr, double, OccupancyTarget, 0.5)                              \
+  F(constexpr, unsigned, EffectiveOOMThreshold,                           \
+    std::numeric_limits<unsigned>::max())                                 \
+  F(constexpr, GCSanitizeConfig, SanitizeConfig)                          \
+  F(constexpr, bool, ShouldRandomizeAllocSpace, false)                    \
+  F(constexpr, bool, ShouldRecordStats, false)                            \
+  F(constexpr, ReleaseUnused, ShouldReleaseUnused, kReleaseUnusedOld)     \
+  F(HERMES_NON_CONSTEXPR, std::string, Name, "")                          \
+  F(HERMES_NON_CONSTEXPR, GCTripwireConfig, TripwireConfig)               \
+  F(constexpr, bool, AllocInYoung, true)                                  \
+  F(constexpr, bool, RevertToYGAtTTI, false)                              \
+  F(constexpr, bool, ProtectMetadata, false)                              \
+  F(HERMES_NON_CONSTEXPR, std::function<void(const GCAnalyticsEvent &)>,  \
+    AnalyticsCallback, nullptr)                                           \
+  F(HERMES_NON_CONSTEXPR, std::function<void(GCEventKind, const char *)>, \
+    Callback, nullptr)
+
+_HERMES_CTORCONFIG_STRUCT(GCConfig, GC_FIELDS, {});
+
+}  // namespace hermes::vm

--- a/modules/hermes-compat/include/hermes/Public/HermesExport.h
+++ b/modules/hermes-compat/include/hermes/Public/HermesExport.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// The shim is always compiled into the app, so there is no import case.
+#ifndef HERMES_EXPORT
+#if defined(_MSC_VER)
+#define HERMES_EXPORT
+#else
+#define HERMES_EXPORT __attribute__((visibility("default")))
+#endif
+#endif

--- a/modules/hermes-compat/include/hermes/Public/RuntimeConfig.h
+++ b/modules/hermes-compat/include/hermes/Public/RuntimeConfig.h
@@ -5,20 +5,61 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/*
+ * The full field set, with Hermes's own defaults, so that code configuring the
+ * VM compiles unchanged.
+ *
+ * Almost none of it has a QuickJS equivalent. Rather than drop settings
+ * silently, makeHermesRuntime() compares the config it is handed against these
+ * defaults and reports every field it cannot honour -- loudly for the ones
+ * that change what JavaScript is allowed to do, such as EnableEval, and once
+ * for tuning fields nothing observable depends on.
+ */
+
 #pragma once
+
+#include <hermes/Public/CrashManager.h>
+#include <hermes/Public/CtorConfig.h>
+#include <hermes/Public/GCConfig.h>
+
+#include <cstdint>
+#include <string>
 
 namespace hermes::vm {
 
-// Empty on purpose. Hermes's version carries about forty fields, several of
-// them security settings such as withEnableEval(false), and QuickJS has no
-// equivalent for most. Accepting and dropping them is the silent divergence
-// this shim exists to prevent, so only the default constructor is offered:
-// makeHermesRuntime() compiles, while anything that configures the VM fails to
-// compile with the field named. Add a field only when a real consumer needs
-// it, and wire that one to QuickJS.
-class RuntimeConfig {
- public:
-  RuntimeConfig() = default;
+enum CompilationMode {
+  SmartCompilation,
+  ForceEagerCompilation,
+  ForceLazyCompilation
 };
+
+class PinnedHermesValue;
+
+#define RUNTIME_FIELDS(F)                                    \
+  F(HERMES_NON_CONSTEXPR, vm::GCConfig, GCConfig)            \
+  F(constexpr, PinnedHermesValue *, RegisterStack, nullptr)  \
+  F(constexpr, unsigned, MaxNumRegisters, 1024 * 1024)       \
+  F(constexpr, bool, EnableJIT, false)                       \
+  F(constexpr, bool, EnableEval, true)                       \
+  F(constexpr, bool, VerifyEvalIR, false)                    \
+  F(constexpr, bool, OptimizedEval, false)                   \
+  F(constexpr, bool, AsyncBreakCheckInEval, false)           \
+  F(constexpr, bool, ES6Promise, true)                       \
+  F(constexpr, bool, ES6Proxy, true)                         \
+  F(constexpr, bool, Intl, true)                             \
+  F(constexpr, bool, TraceEnabled, false)                    \
+  F(HERMES_NON_CONSTEXPR, std::string, TraceScratchPath, "") \
+  F(HERMES_NON_CONSTEXPR, std::string, TraceResultPath, "")  \
+  F(constexpr, bool, EnableSampledStats, false)              \
+  F(constexpr, bool, EnableSampleProfiling, true)            \
+  F(constexpr, bool, RandomizeMemoryLayout, false)           \
+  F(constexpr, unsigned, BytecodeWarmupPercent, 0)           \
+  F(constexpr, bool, TrackIO, false)                         \
+  F(constexpr, bool, EnableHermesInternal, true)             \
+  F(constexpr, bool, EnableHermesInternalTestMethods, false) \
+  F(constexpr, bool, EnableGenerator, true)                  \
+  F(constexpr, uint32_t, VMExperimentFlags, 0)
+
+_HERMES_CTORCONFIG_STRUCT(RuntimeConfig, RUNTIME_FIELDS, {});
 
 }  // namespace hermes::vm

--- a/modules/hermes-compat/include/hermes/Public/RuntimeConfig.h
+++ b/modules/hermes-compat/include/hermes/Public/RuntimeConfig.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace hermes::vm {
+
+// Empty on purpose. Hermes's version carries about forty fields, several of
+// them security settings such as withEnableEval(false), and QuickJS has no
+// equivalent for most. Accepting and dropping them is the silent divergence
+// this shim exists to prevent, so only the default constructor is offered:
+// makeHermesRuntime() compiles, while anything that configures the VM fails to
+// compile with the field named. Add a field only when a real consumer needs
+// it, and wire that one to QuickJS.
+class RuntimeConfig {
+ public:
+  RuntimeConfig() = default;
+};
+
+}  // namespace hermes::vm

--- a/modules/hermes-compat/include/hermes/Public/SamplingProfiler.h
+++ b/modules/hermes-compat/include/hermes/Public/SamplingProfiler.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <hermes/Public/HermesExport.h>
+
+namespace facebook::hermes::sampling_profiler {
+
+// Named so that IHermes::dumpSampledTraceToProfile has a complete return type.
+// QuickJS has no sampling profiler, so a caller that reads a Profile does not
+// compile -- which is the right answer, and happens at build time.
+class HERMES_EXPORT Profile {
+ public:
+  Profile() = default;
+};
+
+}  // namespace facebook::hermes::sampling_profiler

--- a/modules/hermes-compat/include/hermes/hermes.h
+++ b/modules/hermes-compat/include/hermes/hermes.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * A source-compatible <hermes/hermes.h> whose makeHermesRuntime() returns a
+ * QuickJS-backed runtime, so libraries that create their own Hermes runtime --
+ * react-native-worklets, and so react-native-reanimated -- build and run
+ * unmodified. Those libraries select an engine with __has_include(<hermes/
+ * hermes.h>) and have no third-engine branch, so without this they cannot be
+ * used at all.
+ *
+ * This is source compatibility, never ABI compatibility. These headers must
+ * not be on the include path while a real libhermes is on the link line.
+ *
+ * Rule when editing: no member declaration below may be conditional on a
+ * preprocessor macro. Free functions may be; virtual functions and data
+ * members may not. A conditional virtual shifts every vtable slot after it,
+ * and consumers are compiled separately from this shim with flags it does not
+ * control -- the failure is a silent call to the wrong function.
+ */
+
+#pragma once
+
+#include <hermes/DebuggerAPI.h>
+#include <hermes/Public/HermesExport.h>
+#include <hermes/Public/RuntimeConfig.h>
+#include <hermes/Public/SamplingProfiler.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+struct SHUnit;
+struct SHRuntime;
+
+namespace hermes::vm {
+class GCExecTrace {
+ public:
+  GCExecTrace() = default;
+};
+class Runtime;
+}  // namespace hermes::vm
+
+namespace facebook {
+namespace jsi {
+class ThreadSafeRuntime;
+}
+
+namespace hermes {
+
+class HermesRuntime;
+
+/// Engine-global operations that need no runtime instance. The UUIDs match
+/// real Hermes so that castInterface in unmodified third-party code succeeds.
+class HERMES_EXPORT IHermesRootAPI : public jsi::ICast {
+ public:
+  static constexpr jsi::UUID uuid{
+      0xb654d898, 0xdfad, 0x11ef, 0x859a, 0x325096b39f47};
+
+  virtual std::unique_ptr<HermesRuntime> makeHermesRuntime(
+      const ::hermes::vm::RuntimeConfig &runtimeConfig) = 0;
+
+  /// Always false: nothing here produces Hermes bytecode. A caller handed a
+  /// real .hbc bundle takes its "this is source" path and fails in the parser,
+  /// so the shim sniffs the HBC magic and reports, naming the real cause.
+  virtual bool isHermesBytecode(const uint8_t *data, size_t len) = 0;
+  virtual uint32_t getBytecodeVersion() = 0;
+  virtual void prefetchHermesBytecode(const uint8_t *data, size_t len) = 0;
+  virtual bool hermesBytecodeSanityCheck(
+      const uint8_t *data, size_t len, std::string *errorMessage) = 0;
+  virtual void setFatalHandler(void (*handler)(const std::string &)) = 0;
+  virtual std::pair<const uint8_t *, size_t> getBytecodeEpilogue(
+      const uint8_t *data, size_t len) = 0;
+  virtual void enableSamplingProfiler(double meanHzFreq) = 0;
+  virtual void disableSamplingProfiler() = 0;
+  virtual void dumpSampledTraceToFile(const std::string &fileName) = 0;
+  virtual void dumpSampledTraceToStream(std::ostream &stream) = 0;
+  virtual std::unordered_map<std::string, std::vector<std::string>>
+  getExecutedFunctions() = 0;
+  virtual bool isCodeCoverageProfilerEnabled() = 0;
+  virtual void enableCodeCoverageProfiler() = 0;
+  virtual void disableCodeCoverageProfiler() = 0;
+
+ protected:
+  ~IHermesRootAPI() {}
+};
+
+class HERMES_EXPORT ISetFatalHandler : public jsi::ICast {
+ public:
+  static constexpr jsi::UUID uuid{
+      0xda98a610, 0x09cb, 0x11f0, 0x87bf, 0x325096b39f47};
+  virtual void setFatalHandler(void (*handler)(const std::string &)) = 0;
+
+ protected:
+  ~ISetFatalHandler() = default;
+};
+
+/// Hermes-specific per-runtime methods.
+class HERMES_EXPORT IHermes : public jsi::ICast {
+ public:
+  static constexpr jsi::UUID uuid{
+      0xe85cfa22, 0xdfae, 0x11ef, 0xa6f7, 0x325096b39f47};
+
+  virtual ICast *getHermesRootAPI() = 0;
+  virtual void sampledTraceToStreamInDevToolsFormat(std::ostream &stream) = 0;
+  virtual sampling_profiler::Profile dumpSampledTraceToProfile() = 0;
+  virtual void resetTimezoneCache() = 0;
+  virtual void loadSegment(
+      std::unique_ptr<const jsi::Buffer> buffer, const jsi::Value &context) = 0;
+
+  /// QuickJS heap objects do not move, so an object's address is a stable id
+  /// for its lifetime -- the contract Hermes documents, including that an id
+  /// may be reused after the object is collected.
+  virtual uint64_t getUniqueID(const jsi::Object &o) const = 0;
+  virtual uint64_t getUniqueID(const jsi::BigInt &s) const = 0;
+  virtual uint64_t getUniqueID(const jsi::String &s) const = 0;
+  virtual uint64_t getUniqueID(const jsi::PropNameID &pni) const = 0;
+  virtual uint64_t getUniqueID(const jsi::Symbol &sym) const = 0;
+  virtual uint64_t getUniqueID(const jsi::Value &val) const = 0;
+  virtual jsi::Value getObjectForID(uint64_t id) = 0;
+
+  virtual const ::hermes::vm::GCExecTrace &getGCExecTrace() const = 0;
+  virtual std::string getIOTrackingInfoJSON() = 0;
+  virtual debugger::Debugger &getDebugger() = 0;
+
+  struct DebugFlags {};
+
+  virtual void debugJavaScript(
+      const std::string &src, const std::string &sourceURL,
+      const DebugFlags &debugFlags) = 0;
+  virtual void registerForProfiling() = 0;
+  virtual void unregisterForProfiling() = 0;
+
+  /// Backed by the engine's interrupt handler, which the interpreter polls.
+  virtual void asyncTriggerTimeout() = 0;
+  virtual void watchTimeLimit(uint32_t timeoutInMs) = 0;
+  virtual void unwatchTimeLimit() = 0;
+
+  virtual jsi::Value evaluateJavaScriptWithSourceMap(
+      const std::shared_ptr<const jsi::Buffer> &buffer,
+      const std::shared_ptr<const jsi::Buffer> &sourceMapBuf,
+      const std::string &sourceURL) = 0;
+  virtual jsi::Value evaluateSHUnit(SHUnit *(*shUnitCreator)()) = 0;
+  virtual SHRuntime *getSHRuntime() noexcept = 0;
+
+  /// Returns nullptr. Handing back the JSContext* would let a caller
+  /// reinterpret_cast it to hermes::vm::Runtime* and corrupt memory.
+  virtual void *getVMRuntimeUnsafe() const = 0;
+
+ protected:
+  ~IHermes() = default;
+};
+
+class HERMES_EXPORT IHermesTestHelpers : public jsi::ICast {
+ public:
+  static constexpr jsi::UUID uuid{
+      0x664e489a, 0xf941, 0x11ef, 0xa44c, 0x325096b39f47};
+  virtual size_t rootsListLengthForTests() const = 0;
+
+ protected:
+  ~IHermesTestHelpers() = default;
+};
+
+class HermesRuntime : public jsi::Runtime, public IHermes {
+ public:
+  ~HermesRuntime() override = default;
+
+  using jsi::Runtime::castInterface;
+};
+
+HERMES_EXPORT jsi::ICast *makeHermesRootAPI();
+
+HERMES_EXPORT ::hermes::vm::RuntimeConfig hardenedHermesRuntimeConfig();
+
+HERMES_EXPORT std::unique_ptr<HermesRuntime> makeHermesRuntime(
+    const ::hermes::vm::RuntimeConfig &runtimeConfig =
+        ::hermes::vm::RuntimeConfig());
+
+/// Returns nullptr rather than an unlocked runtime: a caller expecting
+/// Hermes's ThreadSafeRuntime semantics should not silently get less.
+HERMES_EXPORT std::unique_ptr<jsi::ThreadSafeRuntime>
+makeThreadSafeHermesRuntime(
+    const ::hermes::vm::RuntimeConfig &runtimeConfig =
+        ::hermes::vm::RuntimeConfig());
+
+}  // namespace hermes
+}  // namespace facebook

--- a/modules/hermes-compat/include/hermes/inspector-modern/chrome/Registration.h
+++ b/modules/hermes-compat/include/hermes/inspector-modern/chrome/Registration.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef HERMES_ENABLE_DEBUGGER
+
+#include <hermes/hermes.h>
+#include <hermes/inspector/RuntimeAdapter.h>
+
+#include <memory>
+#include <string>
+
+namespace facebook::hermes::inspector_modern::chrome {
+
+using DebugSessionToken = int;
+
+/// Defined so debug builds of worklets link. It does not register a target:
+/// the app's main runtime is debuggable through jsinspector-modern and
+/// modules/cdp, a runtime created through this shim is not.
+extern DebugSessionToken enableDebugging(
+    std::unique_ptr<RuntimeAdapter> adapter, const std::string &title);
+extern void disableDebugging(DebugSessionToken session);
+
+}  // namespace facebook::hermes::inspector_modern::chrome
+
+#endif  // HERMES_ENABLE_DEBUGGER

--- a/modules/hermes-compat/include/hermes/inspector/RuntimeAdapter.h
+++ b/modules/hermes-compat/include/hermes/inspector/RuntimeAdapter.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <hermes/hermes.h>
+
+#include <memory>
+
+#ifndef INSPECTOR_EXPORT
+#if defined(_MSC_VER)
+#define INSPECTOR_EXPORT
+#else
+#define INSPECTOR_EXPORT __attribute__((visibility("default")))
+#endif
+#endif
+
+namespace facebook::hermes::inspector_modern {
+
+/// Owns a runtime for the debugger to attach to. Kept because worklets names
+/// the type; see Registration.h for what attaching actually does here.
+class INSPECTOR_EXPORT RuntimeAdapter {
+ public:
+  virtual ~RuntimeAdapter() = 0;
+  virtual HermesRuntime &getRuntime() = 0;
+  virtual void tickleJs();
+};
+
+class INSPECTOR_EXPORT SharedRuntimeAdapter : public RuntimeAdapter {
+ public:
+  explicit SharedRuntimeAdapter(std::shared_ptr<HermesRuntime> runtime);
+  ~SharedRuntimeAdapter() override;
+  HermesRuntime &getRuntime() override;
+
+ private:
+  std::shared_ptr<HermesRuntime> runtime_;
+};
+
+}  // namespace facebook::hermes::inspector_modern

--- a/modules/hermes-compat/src/HermesCompat.cpp
+++ b/modules/hermes-compat/src/HermesCompat.cpp
@@ -1,0 +1,478 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <hermes-compat/Diagnostics.h>
+#include <hermes/hermes.h>
+#include <hermes/inspector/RuntimeAdapter.h>
+#include <jsi/decorator.h>
+#include <jsi/threadsafe.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+#include "QuickJSRuntime.h"
+#include "QuickJSRuntimeFactory.h"
+
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+
+// ---------------------------------------------------------------- diagnostics
+
+namespace qjs::hermescompat {
+namespace {
+
+std::mutex gMutex;
+Handler gHandler;
+std::unordered_set<const void *> gSeen;
+
+const char *name(Severity severity) {
+  switch (severity) {
+    case Severity::Degraded:
+      return "degraded";
+    case Severity::Ignored:
+      return "ignored";
+    case Severity::Unsupported:
+      return "unsupported";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+void setHandler(Handler handler) {
+  std::lock_guard<std::mutex> lock(gMutex);
+  gHandler = std::move(handler);
+}
+
+void report(Severity severity, const char *api, const char *detail) {
+  Handler handler;
+  {
+    std::lock_guard<std::mutex> lock(gMutex);
+    if (!gSeen.insert(api).second) {
+      return;
+    }
+    handler = gHandler;
+  }
+
+  if (handler) {
+    handler(severity, api, detail);
+    return;
+  }
+#ifdef __ANDROID__
+  __android_log_print(
+      ANDROID_LOG_WARN, "hermes-compat", "%s: %s -- %s", name(severity), api,
+      detail);
+#else
+  std::fprintf(
+      stderr, "[hermes-compat] %s: %s -- %s\n", name(severity), api, detail);
+#endif
+}
+
+}  // namespace qjs::hermescompat
+
+// -------------------------------------------------------------------- runtime
+
+namespace facebook::hermes {
+namespace {
+
+namespace diag = qjs::hermescompat;
+using diag::Severity;
+
+/// Hermes bytecode files open with this, little-endian (BytecodeFileFormat.h).
+/// Sniffed so that "this is plain JavaScript" and "this is an HBC bundle this
+/// app can never run" are not reported as the same answer.
+constexpr uint64_t kHermesMagic = 0x1F1903C103BC1FC6ULL;
+
+void degraded(const char *api, const char *why) {
+  degraded(api, why);
+}
+void ignored(const char *api, const char *why) {
+  ignored(api, why);
+}
+void unsupported(const char *api, const char *why) {
+  unsupported(api, why);
+}
+
+bool looksLikeHermesBytecode(const uint8_t *data, size_t len) {
+  if (data == nullptr || len < sizeof(kHermesMagic)) {
+    return false;
+  }
+  uint64_t magic = 0;
+  std::memcpy(&magic, data, sizeof(magic));
+  return magic == kHermesMagic;
+}
+
+class RootAPI final : public IHermesRootAPI, public ISetFatalHandler {
+ public:
+  jsi::ICast *castInterface(const jsi::UUID &uuid) override {
+    if (uuid == IHermesRootAPI::uuid)
+      return static_cast<IHermesRootAPI *>(this);
+    if (uuid == ISetFatalHandler::uuid)
+      return static_cast<ISetFatalHandler *>(this);
+    return nullptr;
+  }
+
+  std::unique_ptr<HermesRuntime> makeHermesRuntime(
+      const ::hermes::vm::RuntimeConfig &config) override;
+
+  bool isHermesBytecode(const uint8_t *data, size_t len) override {
+    if (looksLikeHermesBytecode(data, len)) {
+      unsupported(
+          "IHermesRootAPI::isHermesBytecode",
+          "cannot execute HBC; rebuild as JavaScript or with "
+          "tools/bytecode/qjsc");
+    }
+    return false;
+  }
+
+  uint32_t getBytecodeVersion() override {
+    unsupported(
+        "IHermesRootAPI::getBytecodeVersion",
+        "no HBC version here; returning 0");
+    return 0;
+  }
+
+  void prefetchHermesBytecode(const uint8_t *, size_t) override {
+    ignored(
+        "IHermesRootAPI::prefetchHermesBytecode",
+        "an madvise hint for HBC files; nothing to do");
+  }
+
+  bool hermesBytecodeSanityCheck(
+      const uint8_t *data, size_t len, std::string *errorMessage) override {
+    if (errorMessage != nullptr) {
+      *errorMessage = looksLikeHermesBytecode(data, len)
+                          ? "Hermes bytecode, which this app cannot execute"
+                          : "not Hermes bytecode (this app runs QuickJS)";
+    }
+    return false;
+  }
+
+  void setFatalHandler(void (*)(const std::string &)) override {
+    unsupported(
+        "IHermesRootAPI::setFatalHandler",
+        "no fatal handler exists; it would never be called");
+  }
+
+  std::pair<const uint8_t *, size_t> getBytecodeEpilogue(
+      const uint8_t *, size_t) override {
+    unsupported(
+        "IHermesRootAPI::getBytecodeEpilogue",
+        "an HBC concept; returning empty");
+    return {nullptr, 0};
+  }
+
+  void enableSamplingProfiler(double) override {
+    noProfiler();
+  }
+  void disableSamplingProfiler() override {
+    noProfiler();
+  }
+  void dumpSampledTraceToFile(const std::string &) override {
+    noProfiler();
+  }
+  void dumpSampledTraceToStream(std::ostream &) override {
+    noProfiler();
+  }
+
+  std::unordered_map<std::string, std::vector<std::string>>
+  getExecutedFunctions() override {
+    unsupported(
+        "IHermesRootAPI::getExecutedFunctions", "not tracked; returning empty");
+    return {};
+  }
+
+  bool isCodeCoverageProfilerEnabled() override {
+    return false;
+  }
+  void enableCodeCoverageProfiler() override {
+    noCoverage();
+  }
+  void disableCodeCoverageProfiler() override {
+    noCoverage();
+  }
+
+ private:
+  static void noProfiler() {
+    unsupported(
+        "IHermesRootAPI sampling profiler", "QuickJS has no sampling profiler");
+  }
+  static void noCoverage() {
+    unsupported(
+        "IHermesRootAPI code coverage profiler",
+        "QuickJS has no code coverage profiler");
+  }
+};
+
+RootAPI &rootAPI() {
+  static RootAPI api;
+  return api;
+}
+
+/// RuntimeDecorator forwards every jsi::Runtime virtual to the QuickJS runtime,
+/// so a change to JSI is a compile error here rather than a silent divergence.
+/// Only the Hermes-specific half is written out below.
+class CompatRuntime final
+    : public jsi::RuntimeDecorator<jsi::Runtime, HermesRuntime> {
+ public:
+  explicit CompatRuntime(std::unique_ptr<jsi::Runtime> plain)
+      : jsi::RuntimeDecorator<jsi::Runtime, HermesRuntime>(*plain),
+        owned_(std::move(plain)),
+        quickjs_(dynamic_cast<qjs::QuickJSRuntime *>(owned_.get())) {}
+
+  ~CompatRuntime() override {
+    unwatchTimeLimit();
+  }
+
+  jsi::ICast *castInterface(const jsi::UUID &uuid) override {
+    if (uuid == IHermes::uuid) return static_cast<IHermes *>(this);
+    return plain().castInterface(uuid);
+  }
+
+  ICast *getHermesRootAPI() override {
+    return static_cast<IHermesRootAPI *>(&rootAPI());
+  }
+
+  void sampledTraceToStreamInDevToolsFormat(std::ostream &) override {
+    noProfiler();
+  }
+
+  sampling_profiler::Profile dumpSampledTraceToProfile() override {
+    noProfiler();
+    return {};
+  }
+
+  /// QuickJS reads the zone on every conversion and caches nothing, so there
+  /// is nothing engine-side to invalidate.
+  void resetTimezoneCache() override {}
+
+  void loadSegment(
+      std::unique_ptr<const jsi::Buffer>, const jsi::Value &) override {
+    unsupported(
+        "IHermes::loadSegment", "segmented and RAM bundles are HBC features");
+  }
+
+  uint64_t getUniqueID(const jsi::Object &o) const override {
+    return id(o);
+  }
+  uint64_t getUniqueID(const jsi::BigInt &b) const override {
+    return id(b);
+  }
+  uint64_t getUniqueID(const jsi::String &s) const override {
+    return id(s);
+  }
+  uint64_t getUniqueID(const jsi::PropNameID &p) const override {
+    return id(p);
+  }
+  uint64_t getUniqueID(const jsi::Symbol &s) const override {
+    return id(s);
+  }
+
+  uint64_t getUniqueID(const jsi::Value &v) const override {
+    if (quickjs_ == nullptr ||
+        !(v.isObject() || v.isString() || v.isSymbol() || v.isBigInt())) {
+      return 0;  // Hermes documents 0 as "no id for this value".
+    }
+    return reinterpret_cast<uint64_t>(JS_VALUE_GET_PTR(quickjs_->toJSValue(v)));
+  }
+
+  jsi::Value getObjectForID(uint64_t) override {
+    unsupported(
+        "IHermes::getObjectForID",
+        "no id-to-object registry is kept; returning null");
+    return jsi::Value::null();
+  }
+
+  const ::hermes::vm::GCExecTrace &getGCExecTrace() const override {
+    static const ::hermes::vm::GCExecTrace kEmpty;
+    unsupported("IHermes::getGCExecTrace", "not recorded");
+    return kEmpty;
+  }
+
+  std::string getIOTrackingInfoJSON() override {
+    unsupported("IHermes::getIOTrackingInfoJSON", "not tracked; returning {}");
+    return "{}";
+  }
+
+  debugger::Debugger &getDebugger() override {
+    static debugger::Debugger kEmpty;
+    unsupported(
+        "IHermes::getDebugger",
+        "debugging goes through jsinspector-modern, not this API");
+    return kEmpty;
+  }
+
+  /// Hermes disables optimisation so debug info stays exact; QuickJS's
+  /// interpreter has no separate optimised mode, so this is a plain evaluate.
+  void debugJavaScript(
+      const std::string &src, const std::string &sourceURL,
+      const DebugFlags &) override {
+    plain().evaluateJavaScript(
+        std::make_shared<jsi::StringBuffer>(src), sourceURL);
+  }
+
+  void registerForProfiling() override {
+    noProfiler();
+  }
+  void unregisterForProfiling() override {
+    noProfiler();
+  }
+
+  void asyncTriggerTimeout() override {
+    interrupt_.store(true, std::memory_order_relaxed);
+  }
+
+  void watchTimeLimit(uint32_t timeoutInMs) override {
+    if (quickjs_ == nullptr) return;
+    deadline_.store(nowMs() + timeoutInMs, std::memory_order_relaxed);
+    JS_SetInterruptHandler(
+        quickjs_->runtime(), &CompatRuntime::onInterrupt, this);
+  }
+
+  void unwatchTimeLimit() override {
+    deadline_.store(0, std::memory_order_relaxed);
+    interrupt_.store(false, std::memory_order_relaxed);
+    if (quickjs_ != nullptr) {
+      JS_SetInterruptHandler(quickjs_->runtime(), nullptr, nullptr);
+    }
+  }
+
+  /// The source map is accepted and ignored: QuickJS does not apply source
+  /// maps to stack traces.
+  jsi::Value evaluateJavaScriptWithSourceMap(
+      const std::shared_ptr<const jsi::Buffer> &buffer,
+      const std::shared_ptr<const jsi::Buffer> &,
+      const std::string &sourceURL) override {
+    degraded(
+        "IHermes::evaluateJavaScriptWithSourceMap",
+        "source map ignored; stack traces point at generated code");
+    return plain().evaluateJavaScript(buffer, sourceURL);
+  }
+
+  jsi::Value evaluateSHUnit(SHUnit *(*)()) override {
+    unsupported("IHermes::evaluateSHUnit", "Static Hermes only");
+    return jsi::Value::undefined();
+  }
+
+  SHRuntime *getSHRuntime() noexcept override {
+    return nullptr;
+  }
+
+  void *getVMRuntimeUnsafe() const override {
+    unsupported(
+        "IHermes::getVMRuntimeUnsafe",
+        "returning null; a JSContext cast to hermes::vm::Runtime corrupts");
+    return nullptr;
+  }
+
+ private:
+  template <typename T>
+  uint64_t id(const T &pointer) const {
+    return reinterpret_cast<uint64_t>(
+        JS_VALUE_GET_PTR(qjs::QuickJSRuntime::toJSValue(pointer)));
+  }
+
+  static void noProfiler() {
+    unsupported(
+        "IHermes sampling profiler", "QuickJS has no sampling profiler");
+  }
+
+  static uint64_t nowMs() {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+  }
+
+  static int onInterrupt(JSRuntime *, void *opaque) {
+    auto *self = static_cast<CompatRuntime *>(opaque);
+    if (self->interrupt_.load(std::memory_order_relaxed)) return 1;
+    const uint64_t deadline = self->deadline_.load(std::memory_order_relaxed);
+    return deadline != 0 && nowMs() > deadline ? 1 : 0;
+  }
+
+  std::unique_ptr<jsi::Runtime> owned_;
+  qjs::QuickJSRuntime *quickjs_;
+  std::atomic<uint64_t> deadline_{0};
+  std::atomic<bool> interrupt_{false};
+};
+
+std::unique_ptr<HermesRuntime> RootAPI::makeHermesRuntime(
+    const ::hermes::vm::RuntimeConfig &) {
+  return std::make_unique<CompatRuntime>(qjs::makeQuickJSRuntime());
+}
+
+}  // namespace
+
+jsi::ICast *makeHermesRootAPI() {
+  // RootAPI reaches ICast through both of its bases, so the path is named.
+  return static_cast<IHermesRootAPI *>(&rootAPI());
+}
+
+::hermes::vm::RuntimeConfig hardenedHermesRuntimeConfig() {
+  unsupported(
+      "hardenedHermesRuntimeConfig",
+      "no hardening switches exist; returning a default config");
+  return {};
+}
+
+std::unique_ptr<HermesRuntime> makeHermesRuntime(
+    const ::hermes::vm::RuntimeConfig &config) {
+  return rootAPI().makeHermesRuntime(config);
+}
+
+std::unique_ptr<jsi::ThreadSafeRuntime> makeThreadSafeHermesRuntime(
+    const ::hermes::vm::RuntimeConfig &) {
+  unsupported(
+      "makeThreadSafeHermesRuntime",
+      "returning null rather than an unlocked runtime");
+  return nullptr;
+}
+
+// ------------------------------------------------------------------- adapters
+
+namespace inspector_modern {
+
+RuntimeAdapter::~RuntimeAdapter() = default;
+void RuntimeAdapter::tickleJs() {}
+
+SharedRuntimeAdapter::SharedRuntimeAdapter(
+    std::shared_ptr<HermesRuntime> runtime)
+    : runtime_(std::move(runtime)) {}
+SharedRuntimeAdapter::~SharedRuntimeAdapter() = default;
+HermesRuntime &SharedRuntimeAdapter::getRuntime() {
+  return *runtime_;
+}
+
+}  // namespace inspector_modern
+}  // namespace facebook::hermes
+
+#ifdef HERMES_ENABLE_DEBUGGER
+#include <hermes/inspector-modern/chrome/Registration.h>
+
+namespace facebook::hermes::inspector_modern::chrome {
+
+DebugSessionToken enableDebugging(
+    std::unique_ptr<RuntimeAdapter>, const std::string &) {
+  qjs::hermescompat::report(
+      qjs::hermescompat::Severity::Unsupported, "chrome::enableDebugging",
+      "not registered as a DevTools target; the app's main runtime is, a "
+      "runtime made through this shim is not");
+  static std::atomic<DebugSessionToken> next{1};
+  return next.fetch_add(1, std::memory_order_relaxed);
+}
+
+void disableDebugging(DebugSessionToken) {}
+
+}  // namespace facebook::hermes::inspector_modern::chrome
+#endif  // HERMES_ENABLE_DEBUGGER

--- a/modules/hermes-compat/src/HermesCompat.cpp
+++ b/modules/hermes-compat/src/HermesCompat.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <mutex>
 #include <string>
 #include <unordered_set>
@@ -78,6 +79,12 @@ void report(Severity severity, const char *api, const char *detail) {
 #endif
 }
 
+void resetForTesting() {
+  std::lock_guard<std::mutex> lock(gMutex);
+  gSeen.clear();
+  gHandler = nullptr;
+}
+
 }  // namespace qjs::hermescompat
 
 // -------------------------------------------------------------------- runtime
@@ -94,13 +101,13 @@ using diag::Severity;
 constexpr uint64_t kHermesMagic = 0x1F1903C103BC1FC6ULL;
 
 void degraded(const char *api, const char *why) {
-  degraded(api, why);
+  diag::report(Severity::Degraded, api, why);
 }
 void ignored(const char *api, const char *why) {
-  ignored(api, why);
+  diag::report(Severity::Ignored, api, why);
 }
 void unsupported(const char *api, const char *why) {
-  unsupported(api, why);
+  diag::report(Severity::Unsupported, api, why);
 }
 
 bool looksLikeHermesBytecode(const uint8_t *data, size_t len) {
@@ -173,16 +180,16 @@ class RootAPI final : public IHermesRootAPI, public ISetFatalHandler {
   }
 
   void enableSamplingProfiler(double) override {
-    noProfiler();
+    noProfiler("enableSamplingProfiler");
   }
   void disableSamplingProfiler() override {
-    noProfiler();
+    noProfiler("disableSamplingProfiler");
   }
   void dumpSampledTraceToFile(const std::string &) override {
-    noProfiler();
+    noProfiler("dumpSampledTraceToFile");
   }
   void dumpSampledTraceToStream(std::ostream &) override {
-    noProfiler();
+    noProfiler("dumpSampledTraceToStream");
   }
 
   std::unordered_map<std::string, std::vector<std::string>>
@@ -196,21 +203,18 @@ class RootAPI final : public IHermesRootAPI, public ISetFatalHandler {
     return false;
   }
   void enableCodeCoverageProfiler() override {
-    noCoverage();
+    noCoverage("enableCodeCoverageProfiler");
   }
   void disableCodeCoverageProfiler() override {
-    noCoverage();
+    noCoverage("disableCodeCoverageProfiler");
   }
 
  private:
-  static void noProfiler() {
-    unsupported(
-        "IHermesRootAPI sampling profiler", "QuickJS has no sampling profiler");
+  static void noProfiler(const char *api) {
+    unsupported(api, "QuickJS has no sampling profiler");
   }
-  static void noCoverage() {
-    unsupported(
-        "IHermesRootAPI code coverage profiler",
-        "QuickJS has no code coverage profiler");
+  static void noCoverage(const char *api) {
+    unsupported(api, "QuickJS has no code coverage profiler");
   }
 };
 
@@ -244,17 +248,19 @@ class CompatRuntime final
   }
 
   void sampledTraceToStreamInDevToolsFormat(std::ostream &) override {
-    noProfiler();
+    noProfiler("sampledTraceToStreamInDevToolsFormat");
   }
 
   sampling_profiler::Profile dumpSampledTraceToProfile() override {
-    noProfiler();
+    noProfiler("dumpSampledTraceToProfile");
     return {};
   }
 
-  /// QuickJS reads the zone on every conversion and caches nothing, so there
-  /// is nothing engine-side to invalidate.
-  void resetTimezoneCache() override {}
+  /// QuickJS reads the zone on every conversion and keeps no cache of its
+  /// own, so the one that can go stale is libc's.
+  void resetTimezoneCache() override {
+    ::tzset();
+  }
 
   void loadSegment(
       std::unique_ptr<const jsi::Buffer>, const jsi::Value &) override {
@@ -322,10 +328,10 @@ class CompatRuntime final
   }
 
   void registerForProfiling() override {
-    noProfiler();
+    noProfiler("registerForProfiling");
   }
   void unregisterForProfiling() override {
-    noProfiler();
+    noProfiler("unregisterForProfiling");
   }
 
   void asyncTriggerTimeout() override {
@@ -333,7 +339,12 @@ class CompatRuntime final
   }
 
   void watchTimeLimit(uint32_t timeoutInMs) override {
-    if (quickjs_ == nullptr) return;
+    if (quickjs_ == nullptr) {
+      unsupported(
+          "IHermes::watchTimeLimit",
+          "the wrapped runtime is not a QuickJSRuntime; no limit is enforced");
+      return;
+    }
     deadline_.store(nowMs() + timeoutInMs, std::memory_order_relaxed);
     JS_SetInterruptHandler(
         quickjs_->runtime(), &CompatRuntime::onInterrupt, this);
@@ -382,9 +393,8 @@ class CompatRuntime final
         JS_VALUE_GET_PTR(qjs::QuickJSRuntime::toJSValue(pointer)));
   }
 
-  static void noProfiler() {
-    unsupported(
-        "IHermes sampling profiler", "QuickJS has no sampling profiler");
+  static void noProfiler(const char *api) {
+    unsupported(api, "QuickJS has no sampling profiler");
   }
 
   static uint64_t nowMs() {
@@ -407,8 +417,65 @@ class CompatRuntime final
   std::atomic<bool> interrupt_{false};
 };
 
+/// A config field set away from its Hermes default is a request this engine
+/// cannot carry out. Silently running with the opposite of what was asked is
+/// the failure this shim exists to prevent, so each one is named: unsupported
+/// where it changes what JavaScript may do, ignored where nothing observable
+/// depends on it.
+void reportUnhonoured(const ::hermes::vm::RuntimeConfig &config) {
+  using Config = ::hermes::vm::RuntimeConfig;
+#define QJS_IF_SET(FIELD) \
+  if (config.get##FIELD() != Config::getDefault##FIELD())
+
+  QJS_IF_SET(EnableEval)
+  unsupported("RuntimeConfig::EnableEval", "eval and Function stay enabled");
+  QJS_IF_SET(ES6Promise)
+  unsupported(
+      "RuntimeConfig::ES6Promise", "Promise stays as the engine has it");
+  QJS_IF_SET(ES6Proxy)
+  unsupported("RuntimeConfig::ES6Proxy", "Proxy stays as the engine has it");
+  QJS_IF_SET(Intl)
+  unsupported("RuntimeConfig::Intl", "Intl stays as the engine has it");
+  QJS_IF_SET(EnableGenerator)
+  unsupported("RuntimeConfig::EnableGenerator", "generators stay enabled");
+  QJS_IF_SET(EnableHermesInternal)
+  unsupported(
+      "RuntimeConfig::EnableHermesInternal",
+      "HermesInternal is installed by the runtime, not by this");
+  QJS_IF_SET(MaxNumRegisters)
+  unsupported(
+      "RuntimeConfig::MaxNumRegisters", "the stack limit is the engine's own");
+  QJS_IF_SET(VMExperimentFlags)
+  unsupported("RuntimeConfig::VMExperimentFlags", "no Hermes VM to configure");
+
+  QJS_IF_SET(EnableJIT)
+  ignored("RuntimeConfig::EnableJIT", "QuickJS interprets; there is no JIT");
+  QJS_IF_SET(TraceEnabled)
+  ignored("RuntimeConfig::TraceEnabled", "no synth trace is recorded");
+  QJS_IF_SET(TrackIO)
+  ignored("RuntimeConfig::TrackIO", "no IO tracking");
+  QJS_IF_SET(EnableSampleProfiling)
+  ignored("RuntimeConfig::EnableSampleProfiling", "no sampling profiler");
+  QJS_IF_SET(EnableSampledStats)
+  ignored("RuntimeConfig::EnableSampledStats", "no sampled stats");
+  QJS_IF_SET(BytecodeWarmupPercent)
+  ignored("RuntimeConfig::BytecodeWarmupPercent", "an HBC warmup hint");
+  QJS_IF_SET(RandomizeMemoryLayout)
+  ignored("RuntimeConfig::RandomizeMemoryLayout", "layout is the allocator's");
+#undef QJS_IF_SET
+
+  const auto &gc = config.getGCConfig();
+  using GC = ::hermes::vm::GCConfig;
+  if (gc.getMinHeapSize() != GC::getDefaultMinHeapSize() ||
+      gc.getInitHeapSize() != GC::getDefaultInitHeapSize() ||
+      gc.getMaxHeapSize() != GC::getDefaultMaxHeapSize()) {
+    ignored("RuntimeConfig::GCConfig", "QuickJS sizes its own heap");
+  }
+}
+
 std::unique_ptr<HermesRuntime> RootAPI::makeHermesRuntime(
-    const ::hermes::vm::RuntimeConfig &) {
+    const ::hermes::vm::RuntimeConfig &config) {
+  reportUnhonoured(config);
   return std::make_unique<CompatRuntime>(qjs::makeQuickJSRuntime());
 }
 

--- a/modules/hermes-compat/test/hermes_compat_test.cpp
+++ b/modules/hermes-compat/test/hermes_compat_test.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) Ammar Ahmed.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <hermes-compat/Diagnostics.h>
+#include <hermes/hermes.h>
+#include <hermes/inspector/RuntimeAdapter.h>
+#include <jsi/threadsafe.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using facebook::jsi::Value;
+namespace hc = facebook::hermes;
+namespace diag = qjs::hermescompat;
+
+namespace {
+
+/// Collects what the shim reports, so a test can assert that an API said it
+/// was unsupported rather than failing quietly.
+class Reports {
+ public:
+  Reports() {
+    diag::resetForTesting();
+    diag::setHandler(
+        [this](diag::Severity severity, const char *api, const char *detail) {
+          entries_.push_back({severity, api, detail});
+        });
+  }
+  ~Reports() {
+    diag::resetForTesting();
+  }
+
+  size_t count() const {
+    return entries_.size();
+  }
+
+  bool saw(diag::Severity severity, const std::string &api) const {
+    for (const auto &e : entries_) {
+      if (e.severity == severity && e.api.find(api) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  struct Entry {
+    diag::Severity severity;
+    std::string api;
+    std::string detail;
+  };
+  std::vector<Entry> entries_;
+};
+
+hc::IHermes &hermesOf(hc::HermesRuntime &runtime) {
+  auto *iface = runtime.castInterface(hc::IHermes::uuid);
+  EXPECT_NE(iface, nullptr);
+  return *static_cast<hc::IHermes *>(iface);
+}
+
+}  // namespace
+
+// The point of the whole shim: a library that asks Hermes for a runtime gets
+// one that runs JavaScript.
+TEST(HermesCompat, MakeHermesRuntimeRunsJavaScript) {
+  auto runtime = hc::makeHermesRuntime();
+  ASSERT_NE(runtime, nullptr);
+  EXPECT_EQ(
+      runtime
+          ->evaluateJavaScript(
+              std::make_shared<facebook::jsi::StringBuffer>("1 + 2"), "t")
+          .getNumber(),
+      3);
+}
+
+TEST(HermesCompat, RootAPIAndRuntimeAnswerTheirInterfaces) {
+  auto *root = hc::makeHermesRootAPI();
+  ASSERT_NE(root, nullptr);
+  EXPECT_NE(root->castInterface(hc::IHermesRootAPI::uuid), nullptr);
+  EXPECT_NE(root->castInterface(hc::ISetFatalHandler::uuid), nullptr);
+
+  auto runtime = hc::makeHermesRuntime();
+  EXPECT_NE(runtime->castInterface(hc::IHermes::uuid), nullptr);
+}
+
+// An unknown UUID must fall through to the QuickJS runtime rather than being
+// answered with the Hermes interface.
+TEST(HermesCompat, UnknownInterfaceIsNotAnsweredWithIHermes) {
+  auto runtime = hc::makeHermesRuntime();
+  constexpr facebook::jsi::UUID kUnknown{
+      0x00000000, 0x0000, 0x0000, 0x0000, 0x000000000000};
+  auto *iface = runtime->castInterface(kUnknown);
+  EXPECT_NE(iface, static_cast<void *>(&hermesOf(*runtime)));
+}
+
+TEST(HermesCompat, UniqueIDIsStablePerObjectAndZeroForNonPointers) {
+  Reports reports;
+  auto runtime = hc::makeHermesRuntime();
+  auto &hermes = hermesOf(*runtime);
+
+  auto a = facebook::jsi::Object(*runtime);
+  auto b = facebook::jsi::Object(*runtime);
+  EXPECT_NE(hermes.getUniqueID(a), 0u);
+  EXPECT_EQ(hermes.getUniqueID(a), hermes.getUniqueID(a));
+  EXPECT_NE(hermes.getUniqueID(a), hermes.getUniqueID(b));
+
+  EXPECT_EQ(hermes.getUniqueID(Value(42)), 0u);
+  EXPECT_EQ(hermes.getUniqueID(Value::undefined()), 0u);
+}
+
+// A real Hermes bytecode bundle must be named as the cause, not reported as
+// "not bytecode" like ordinary source.
+TEST(HermesCompat, HermesBytecodeIsRecognisedAndRefused) {
+  Reports reports;
+  auto *root = static_cast<hc::IHermesRootAPI *>(
+      hc::makeHermesRootAPI()->castInterface(hc::IHermesRootAPI::uuid));
+
+  const uint8_t hbc[] = {0xC6, 0x1F, 0xBC, 0x03, 0xC1, 0x03, 0x19, 0x1F, 0x00};
+  EXPECT_FALSE(root->isHermesBytecode(hbc, sizeof(hbc)));
+  EXPECT_TRUE(reports.saw(diag::Severity::Unsupported, "isHermesBytecode"));
+
+  const uint8_t js[] = "var x = 1;";
+  std::string why;
+  EXPECT_FALSE(root->hermesBytecodeSanityCheck(js, sizeof(js), &why));
+  EXPECT_NE(why.find("not Hermes bytecode"), std::string::npos);
+}
+
+// Unsupported APIs must return something a caller cannot mistake for success.
+TEST(HermesCompat, UnsupportedAPIsFailSafelyAndSaySo) {
+  Reports reports;
+  auto runtime = hc::makeHermesRuntime();
+  auto &hermes = hermesOf(*runtime);
+
+  EXPECT_EQ(hermes.getVMRuntimeUnsafe(), nullptr);
+  EXPECT_EQ(hermes.getSHRuntime(), nullptr);
+  EXPECT_TRUE(hermes.getObjectForID(1).isNull());
+  EXPECT_EQ(hc::makeThreadSafeHermesRuntime(), nullptr);
+
+  auto *root = static_cast<hc::IHermesRootAPI *>(
+      hc::makeHermesRootAPI()->castInterface(hc::IHermesRootAPI::uuid));
+  EXPECT_EQ(root->getBytecodeVersion(), 0u);
+  EXPECT_EQ(root->getBytecodeEpilogue(nullptr, 0).first, nullptr);
+  EXPECT_FALSE(root->isCodeCoverageProfilerEnabled());
+
+  EXPECT_TRUE(reports.saw(diag::Severity::Unsupported, "getVMRuntimeUnsafe"));
+  EXPECT_TRUE(reports.saw(diag::Severity::Unsupported, "getObjectForID"));
+  EXPECT_TRUE(reports.saw(diag::Severity::Unsupported, "getBytecodeVersion"));
+}
+
+// Each API reports under its own name, and only once however often it is hit.
+TEST(HermesCompat, EachAPIReportsOnceUnderItsOwnName) {
+  Reports reports;
+  auto *root = static_cast<hc::IHermesRootAPI *>(
+      hc::makeHermesRootAPI()->castInterface(hc::IHermesRootAPI::uuid));
+
+  root->enableSamplingProfiler(100);
+  root->enableSamplingProfiler(100);
+  root->disableSamplingProfiler();
+
+  EXPECT_EQ(reports.count(), 2u);
+  EXPECT_TRUE(
+      reports.saw(diag::Severity::Unsupported, "enableSamplingProfiler"));
+  EXPECT_TRUE(
+      reports.saw(diag::Severity::Unsupported, "disableSamplingProfiler"));
+}
+
+// Degraded, not unsupported: the code runs, the source map does not apply.
+TEST(HermesCompat, SourceMapEvaluationRunsAndReportsDegraded) {
+  Reports reports;
+  auto runtime = hc::makeHermesRuntime();
+  auto &hermes = hermesOf(*runtime);
+
+  auto value = hermes.evaluateJavaScriptWithSourceMap(
+      std::make_shared<facebook::jsi::StringBuffer>("6 * 7"),
+      std::make_shared<facebook::jsi::StringBuffer>("{}"), "t.js");
+  EXPECT_EQ(value.getNumber(), 42);
+  EXPECT_TRUE(reports.saw(diag::Severity::Degraded, "SourceMap"));
+}
+
+TEST(HermesCompat, DebugJavaScriptEvaluates) {
+  auto runtime = hc::makeHermesRuntime();
+  hc::IHermes::DebugFlags flags;
+  hermesOf(*runtime).debugJavaScript("globalThis.ran = 7;", "t.js", flags);
+  EXPECT_EQ(runtime->global().getProperty(*runtime, "ran").getNumber(), 7);
+}
+
+// watchTimeLimit is a real capability here, not a stub: it must stop a loop
+// that would otherwise never return.
+TEST(HermesCompat, WatchTimeLimitInterruptsARunawayLoop) {
+  auto runtime = hc::makeHermesRuntime();
+  auto &hermes = hermesOf(*runtime);
+  hermes.watchTimeLimit(50);
+
+  const auto start = std::chrono::steady_clock::now();
+  // Bounded so that a broken interrupt fails the test instead of hanging.
+  EXPECT_ANY_THROW(runtime->evaluateJavaScript(
+      std::make_shared<facebook::jsi::StringBuffer>(
+          "var i = 0; while (i < 2e9) { i++; } i"),
+      "loop.js"));
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_LT(
+      std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), 10);
+
+  hermes.unwatchTimeLimit();
+}
+
+TEST(HermesCompat, AsyncTriggerTimeoutInterrupts) {
+  auto runtime = hc::makeHermesRuntime();
+  auto &hermes = hermesOf(*runtime);
+  hermes.watchTimeLimit(1000 * 60);
+  hermes.asyncTriggerTimeout();
+
+  EXPECT_ANY_THROW(runtime->evaluateJavaScript(
+      std::make_shared<facebook::jsi::StringBuffer>(
+          "var i = 0; while (i < 2e9) { i++; } i"),
+      "loop.js"));
+  hermes.unwatchTimeLimit();
+}
+
+// After unwatch, ordinary code must still run.
+TEST(HermesCompat, UnwatchTimeLimitRestoresNormalExecution) {
+  auto runtime = hc::makeHermesRuntime();
+  auto &hermes = hermesOf(*runtime);
+  hermes.watchTimeLimit(1);
+  hermes.unwatchTimeLimit();
+  EXPECT_EQ(
+      runtime
+          ->evaluateJavaScript(
+              std::make_shared<facebook::jsi::StringBuffer>("1 + 1"), "t")
+          .getNumber(),
+      2);
+}
+
+TEST(HermesCompat, ResetTimezoneCacheDoesNotCrash) {
+  auto runtime = hc::makeHermesRuntime();
+  hermesOf(*runtime).resetTimezoneCache();
+  SUCCEED();
+}
+
+TEST(HermesCompat, SharedRuntimeAdapterHandsBackItsRuntime) {
+  std::shared_ptr<hc::HermesRuntime> runtime = hc::makeHermesRuntime();
+  hc::inspector_modern::SharedRuntimeAdapter adapter(runtime);
+  EXPECT_EQ(&adapter.getRuntime(), runtime.get());
+  adapter.tickleJs();
+}
+
+// The whole point of carrying the real field set: code that configures the VM
+// must compile, not fail on a header that left the fields out.
+TEST(HermesCompatConfig, BuilderCompilesAndRoundTrips) {
+  auto config = ::hermes::vm::RuntimeConfig::Builder()
+                    .withEnableEval(false)
+                    .withIntl(false)
+                    .withMaxNumRegisters(2048)
+                    .withGCConfig(::hermes::vm::GCConfig::Builder()
+                                      .withInitHeapSize(1 << 20)
+                                      .withName("test")
+                                      .build())
+                    .build();
+
+  EXPECT_FALSE(config.getEnableEval());
+  EXPECT_FALSE(config.getIntl());
+  EXPECT_EQ(config.getMaxNumRegisters(), 2048u);
+  EXPECT_EQ(config.getGCConfig().getInitHeapSize(), 1u << 20);
+  EXPECT_EQ(config.getGCConfig().getName(), "test");
+
+  // rebuild() keeps what was set and lets one field change.
+  auto again = config.rebuild().withIntl(true).build();
+  EXPECT_TRUE(again.getIntl());
+  EXPECT_FALSE(again.getEnableEval());
+}
+
+TEST(HermesCompatConfig, DefaultsMatchHermesAndReportNothing) {
+  Reports reports;
+  ::hermes::vm::RuntimeConfig config;
+  EXPECT_TRUE(config.getEnableEval());
+  EXPECT_TRUE(config.getES6Promise());
+  EXPECT_TRUE(config.getES6Proxy());
+  EXPECT_TRUE(config.getIntl());
+  EXPECT_FALSE(config.getEnableJIT());
+
+  auto runtime = hc::makeHermesRuntime(config);
+  ASSERT_NE(runtime, nullptr);
+  EXPECT_EQ(reports.count(), 0u);
+}
+
+// A field this engine cannot honour must be named, not dropped.
+TEST(HermesCompatConfig, SecuritySettingsAreReportedUnsupported) {
+  Reports reports;
+  auto config =
+      ::hermes::vm::RuntimeConfig::Builder().withEnableEval(false).build();
+
+  auto runtime = hc::makeHermesRuntime(config);
+  ASSERT_NE(runtime, nullptr);
+  EXPECT_TRUE(reports.saw(diag::Severity::Unsupported, "EnableEval"));
+
+  // and it really is not honoured, which is why it had to be said out loud
+  EXPECT_EQ(
+      runtime
+          ->evaluateJavaScript(
+              std::make_shared<facebook::jsi::StringBuffer>("eval('1+1')"), "t")
+          .getNumber(),
+      2);
+}
+
+TEST(HermesCompatConfig, TuningSettingsAreReportedIgnored) {
+  Reports reports;
+  auto config = ::hermes::vm::RuntimeConfig::Builder()
+                    .withEnableJIT(true)
+                    .withGCConfig(::hermes::vm::GCConfig::Builder()
+                                      .withMaxHeapSize(1 << 28)
+                                      .build())
+                    .build();
+
+  auto runtime = hc::makeHermesRuntime(config);
+  ASSERT_NE(runtime, nullptr);
+  EXPECT_TRUE(reports.saw(diag::Severity::Ignored, "EnableJIT"));
+  EXPECT_TRUE(reports.saw(diag::Severity::Ignored, "GCConfig"));
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "modules/cdp/quickjs-cdp.h",
     "modules/cdp/quickjs-cdp.c",
     "modules/cdp/react",
+    "modules/hermes-compat/include",
+    "modules/hermes-compat/src",
     "scripts/postinstall.js",
     "scripts/react_native_quickjs_pods.rb",
     "*.podspec",


### PR DESCRIPTION
A source-compatible `<hermes/hermes.h>` whose `makeHermesRuntime()` returns a QuickJS-backed runtime, so libraries that create their own Hermes runtime build and run unmodified.

## Why it is needed

`react-native-worklets`, and so `react-native-reanimated`, does not use the app's JavaScript runtime. It creates its own and picks the engine at compile time from `__has_include(<hermes/hermes.h>)`, with no third branch. Expo's `ExpoModulesJSI` calls `facebook::hermes::makeHermesRuntime` directly — that is the one undefined Hermes symbol keeping `hermes-engine`, and so `hermes.framework`, in every Expo iOS app. Without this shim neither library can be used on QuickJS at all.

## Shape

`makeHermesRuntime()` returns a real `jsi::Runtime`. Every JSI method is forwarded by `jsi::RuntimeDecorator`, so a change to JSI is a compile error here rather than a silent divergence — only the Hermes-specific half is written out.

Hermes-specific methods are either implemented against a genuine QuickJS capability, or they report and return something that fails safely. `watchTimeLimit` uses the engine's interrupt handler, `getUniqueID` uses the object address, `resetTimezoneCache` calls `tzset`. `getVMRuntimeUnsafe()` returns null rather than a `JSContext *` a caller would cast to `hermes::vm::Runtime` and corrupt; `makeThreadSafeHermesRuntime()` returns null rather than an unlocked runtime. Nothing aborts, and nothing fails quietly.

`RuntimeConfig` and `GCConfig` carry Hermes's full field set with Hermes's defaults, so code configuring the VM compiles. Since nothing configures QuickJS, `makeHermesRuntime` diffs the config against those defaults and names every field it cannot honour — unsupported where the field changes what JavaScript may do, such as `EnableEval`, ignored for tuning. A default config reports nothing.

## Ported, not copied

This is a rewrite of the 1,400-line module in the old tree, with the same API surface — 58 declarations, compared mechanically, and the same UUIDs so `castInterface` in unmodified third-party code still resolves. One `.cpp` instead of three, a diagnostics surface of two functions instead of six, and one-line reports instead of a paragraph per method.

Two things were deliberately kept because they are load-bearing rather than stylistic: the `RuntimeDecorator`, and the rule that no member declaration in `include/hermes/**` may be conditional on a preprocessor macro. Consumers are compiled separately from this shim with flags it does not control, so a conditional virtual shifts every later vtable slot and the failure is a silent call to the wrong function.

## Tests

18, registered with ctest as `hermes_compat`: runtime creation, interface casting, unique-ID stability, HBC detection, safe returns, per-API report naming, degraded source-map evaluation, `debugJavaScript`, both interrupt paths, unwatch, `tzset`, the runtime adapter, and four covering the config — that a builder compiles and round-trips, that defaults report nothing, that `withEnableEval(false)` reports unsupported *and* that `eval` still works, which is why it had to be said out loud.

Writing them was worth it immediately: they caught the three report helpers calling themselves after a bad search-and-replace. Infinite recursion with no side effects is undefined, so clang at `-O2` deleted the bodies — the code compiled, linked, and every diagnostic in the shim silently did nothing.

## Not ABI compatibility

These headers must never be on the include path while a real `libhermes` is on the link line.

## Shipping it

Both platforms are wired, and off by default on both, because publishing `<hermes/hermes.h>` or a library named after the Hermes engine changes what every Hermes-detecting library in the app believes. That should be a decision, not a side effect of installing a pod.

**iOS** — `ENV["RNQJS_HERMES_COMPAT"] = "1"` in the Podfile enables a `HermesCompat` subspec. `header_mappings_dir` preserves the tree so `<hermes/inspector-modern/chrome/Registration.h>` resolves rather than being flattened, and `pod install` raises if the `hermes-engine` pod is also present: source compatibility is not ABI compatibility, and two `<hermes/hermes.h>` on one search path means pod ordering decides which `makeHermesRuntime` wins.

**Android** — `-PrnqjsHermesCompat=true` builds the shim as `libhermesvm.so`. Not `libhermes.so`: React Native's imported `hermes` target points at `libhermesvm.so` as of 0.85, so that is the name a consumer records as NEEDED. The old tree shipped `libhermes.so`, which was right for 0.81 and would sit unopened in the APK today.

It links `libquickjsinstancejni.so` rather than compiling the engine a second time. Verified on the built artifact: 102 KB, exports `makeHermesRuntime`, no `JS_NewRuntime` defined inside it, `makeQuickJSRuntime` resolved through `DT_NEEDED`.

`libhermestooling.so` is deliberately not shimmed. It arrives through `libhermesinstancejni.so` — React Native's *Hermes* runtime factory — which a QuickJS app replaces with `QuickJSInstance`, so nothing loads it.

## Not done here

A real `react-native-worklets` build against the shim. The old tree validated against it; this port has been verified by symbol and by artifact, not by a consumer.
