### PR TITLE
Say a function was stripped, not native, when its source is gone

### DIFF
--- a/engine/patches/0007-stripped-source-tostring.patch
+++ b/engine/patches/0007-stripped-source-tostring.patch
@@ -1,0 +1,72 @@
+Subject: say a function was stripped, not native, when its source is gone
+
+What this does
+  When a function is loaded from bytecode whose embedded source text was
+  stripped at compile time (qjsc --strip-source), Function.prototype.toString
+  now reports `[stripped source]` instead of `[native code]`.
+
+Why we need it
+  Stripping the source text is a size win, but it cost a lie: every function
+  it touched stringified as `[native code]`, indistinguishable from a real C
+  built-in. That makes debugging confusing -- a function someone wants to read
+  looks like an engine primitive, and there is no way to tell the two apart.
+  The declaration survives stripping, so this preserves that truth: the
+  function is real, it is just source-less.
+
+What it adds
+  Nothing public. A bytecode function whose `b->source` is missing (rather
+  than a genuine C function, which has no function_bytecode at all) now
+  stringifies as:
+
+    function name() {
+        [stripped source]
+    }
+
+Needs a bytecode version bump
+  No. This is a toString change only; the bytecode format is untouched.
+
+Notes
+  A real native function never has a JSFunctionBytecode, so this only fires
+  on bytecode functions that lost their source. Both stringify as
+  `function`, matching what the engine already did and what node prints for
+  its built-ins.
+diff --git a/quickjs.c b/quickjs.c
+index 7ad7e9b..edef01a 100644
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -43038,17 +43038,23 @@ static JSValue js_function_toString(JSContext *ctx, JSValueConst this_val,
+                                     int argc, JSValueConst *argv)
+ {
+     JSObject *p;
++    bool source_stripped;
+     JSFunctionKindEnum func_kind = JS_FUNC_NORMAL;
+ 
+     if (check_function(ctx, this_val))
+         return JS_EXCEPTION;
+ 
+     p = JS_VALUE_GET_OBJ(this_val);
++    source_stripped = false;
+     if (js_class_has_bytecode(p->class_id)) {
+         JSFunctionBytecode *b = p->u.func.function_bytecode;
+         /* `b->source` must be pure ASCII or UTF-8 encoded */
+         if (b->source)
+             return JS_NewStringLen(ctx, b->source, b->source_len);
++        /* The embedded source was stripped at compile time (qjsc
++         * --strip-source); only the declaration survives, so say so instead
++         * of pretending this is a native C function. */
++        source_stripped = true;
+     }
+     {
+         JSValue name;
+@@ -43069,7 +43075,10 @@ static JSValue js_function_toString(JSContext *ctx, JSValueConst this_val,
+             pref = "async function *";
+             break;
+         }
+-        suff = "() {\n    [native code]\n}";
++        if (source_stripped)
++            suff = "() {\n    [stripped source]\n}";
++        else
++            suff = "() {\n    [native code]\n}";
+         name = JS_GetProperty(ctx, this_val, JS_ATOM_name);
+         if (JS_IsUndefined(name))
+             name = js_empty_string(ctx->rt);

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -17,6 +17,7 @@ what we changed and why without opening a single `.patch` file.
 | `0004` | Lets the debugger ask where each stack frame is | Chrome DevTools shows a full call stack, not just the line that stopped | `JS_GetFrameInfoAtLevel` | No |
 | `0005` | Turns the debugger's per-statement callback on and off cheaply | A debugger must stay installed all session; idle, the callback cost 4,040ns per statement against 546ns with none | `JS_SetDebugTraceArmed` | No |
 | `0006` | Lets us attach native data to a JavaScript object where script cannot see or overwrite it | The engine's embedder slot only exists on objects the embedder created, and this data attaches to any object. The alternative, a WeakMap, enters JavaScript on every read and write: reads went 11.1ns to 4.4ns, writes 59.5ns to 8.6ns | `JS_NewPrivateSymbol` | No |
+| `0007` | Makes a stripped bytecode function stringify as `[stripped source]` rather than `[native code]` | Stripping the source text made every affected function indistinguishable from a C built-in, which is a lie that confuses debugging | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -27,12 +27,16 @@
       "sha256": "cf4ba5df3779f81c1721abab677381de5174ed34323bcb5cee68f2f5cf572edd"
     },
     {
+      "name": "0007-stripped-source-tostring.patch",
+      "sha256": "5543d3f33108b3666ccc2317b65afc3ae132a8a12e223ed9f6defeaef2367b8b"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "1a89bc63c09a7411d3f5d8cacbccbb7c525ad37ec4f7f07ee130f5ade736d428"
     }
   ],
   "files": {
-    "quickjs.c": "e59a0172640094f35db7238cb9a0b4ed38152b7388142cdc9a4aa53447cfa80f",
+    "quickjs.c": "9016fa1b5e6682c0c45fef8d1b057aa44cfad95ff1eb50e3432ad520187a86e1",
     "libregexp.c": "27cd5fb4f4f0d8c05fea4cb0ddcd4dede7f39364e87f0f5610cfc25a89908158",
     "libunicode.c": "d88f53190ad772dd09b2beb93ffb8fc3097852f4987485aac8663a00189c43eb",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -43038,17 +43038,23 @@ static JSValue js_function_toString(JSContext *ctx, JSValueConst this_val,
                                     int argc, JSValueConst *argv)
 {
     JSObject *p;
+    bool source_stripped;
     JSFunctionKindEnum func_kind = JS_FUNC_NORMAL;
 
     if (check_function(ctx, this_val))
         return JS_EXCEPTION;
 
     p = JS_VALUE_GET_OBJ(this_val);
+    source_stripped = false;
     if (js_class_has_bytecode(p->class_id)) {
         JSFunctionBytecode *b = p->u.func.function_bytecode;
         /* `b->source` must be pure ASCII or UTF-8 encoded */
         if (b->source)
             return JS_NewStringLen(ctx, b->source, b->source_len);
+        /* The embedded source was stripped at compile time (qjsc
+         * --strip-source); only the declaration survives, so say so instead
+         * of pretending this is a native C function. */
+        source_stripped = true;
     }
     {
         JSValue name;
@@ -43069,7 +43075,10 @@ static JSValue js_function_toString(JSContext *ctx, JSValueConst this_val,
             pref = "async function *";
             break;
         }
-        suff = "() {\n    [native code]\n}";
+        if (source_stripped)
+            suff = "() {\n    [stripped source]\n}";
+        else
+            suff = "() {\n    [native code]\n}";
         name = JS_GetProperty(ctx, this_val, JS_ATOM_name);
         if (JS_IsUndefined(name))
             name = js_empty_string(ctx->rt);

--- a/tests/bytecode_test.cpp
+++ b/tests/bytecode_test.cpp
@@ -379,10 +379,10 @@ TEST(Bytecode, StrippedBytecodeKeepsLineAndColumnInformation) {
 
 TEST(Bytecode, StrippedBytecodeDegradesFunctionToString) {
   // What stripping costs, pinned so the trade is explicit rather than
-  // discovered. The placeholder is spec-conformant NativeFunction syntax and
-  // matches what node prints for a built-in; note that the *kind* is not
-  // reflected -- an async function and a class both stringify as `function`,
-  // which is also what node does for its built-ins.
+  // discovered. The placeholder is spec-conformant NativeFunction syntax;
+  // note that the *kind* is not reflected -- an async function and a class
+  // both stringify as `function`, which is also what node does for its
+  // built-ins.
   const std::string source =
       "function named(a, b) { return a + b; }\n"
       "async function asyncFn() {}\n"
@@ -408,9 +408,9 @@ TEST(Bytecode, StrippedBytecodeDegradesFunctionToString) {
       "class Klass {}");
   EXPECT_EQ(
       runFor("--strip-source"),
-      "function named() {\n    [native code]\n}~"
-      "function asyncFn() {\n    [native code]\n}~"
-      "function Klass() {\n    [native code]\n}");
+      "function named() {\n    [stripped source]\n}~"
+      "function asyncFn() {\n    [stripped source]\n}~"
+      "function Klass() {\n    [stripped source]\n}");
 }
 
 TEST(Bytecode, SyntaxErrorInSourceThrows) {

--- a/tools/bytecode/qjsc.c
+++ b/tools/bytecode/qjsc.c
@@ -24,8 +24,10 @@
  * `--strip-source` drops the embedded source text of every function: 3.30 MB
  * -> 1.16 MB on a 990 KB production Metro bundle, and the same saving in
  * resident memory. It costs Function.prototype.toString, which then reports
- * `[native code]`. Line and column numbers are written under a separate flag
- * and are unaffected, so error.stack is byte-identical either way.
+ * `[stripped source]` instead of the original source, and so stays
+ * distinguishable from a real native function. Line and column numbers are
+ * written under a separate flag and are unaffected, so error.stack is
+ * byte-identical either way.
  *
  * JS_WRITE_OBJ_STRIP_DEBUG is deliberately not exposed. It saves a further
  * 0.18 MB and destroys every line and column number in every stack trace,


### PR DESCRIPTION
`qjsc --strip-source` drops the embedded source text of every function — 3.30 MB to 1.16 MB on a 990 KB production Metro bundle, and the same saving resident.

It cost a lie. Every function it touched stringified as `[native code]`, indistinguishable from a real C built-in, so a function someone wanted to read looked like an engine primitive with no way to tell the two apart.

The declaration survives stripping, so `Function.prototype.toString` now says what actually happened:

```js
function named() {
    [stripped source]
}
```

## How

Engine patch `0007`. A real native function has no `JSFunctionBytecode` at all, so the branch is on a bytecode function whose `b->source` is missing — that is exactly the stripped case, and nothing else reaches it.

**No bytecode version bump.** This is a `toString` change; the serialized format is untouched.

## Test plan

- `tests/bytecode_test.cpp` pins the new output for a function, an async function and a class. The test already existed to make the cost of stripping explicit rather than discovered; it now pins the improved cost.
- Full host suite green, 12/12, including `differential` and `differential_bytecode`.
- `apply-patches --check` and `sync-quickjs-rel --check` both clean: 8 patches applied, projection up to date.

The kind is still not reflected — an async function and a class both stringify as `function`, which is what the engine did before and what node prints for its built-ins.