### PR TITLE
harden: add integer overflow check in qjsc.c

### DIFF
--- a/tools/bytecode/qjsc.c
+++ b/tools/bytecode/qjsc.c
@@ -56,7 +56,7 @@ static uint8_t *read_file(const char *path, size_t *out_len) {
     return NULL;
   }
   long n = ftell(f);
-  if (n < 0 || fseek(f, 0, SEEK_SET) != 0) {
+  if (n < 0 || (size_t)n >= SIZE_MAX || fseek(f, 0, SEEK_SET) != 0) {
     fclose(f);
     return NULL;
   }


### PR DESCRIPTION
## Summary
Harden input handling in `tools/bytecode/qjsc.c` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `tools/bytecode/qjsc.c:60` |
| **Assessment** | Defensive hardening |
| **CWE** | CWE-190 |

**Description**: The read_file function performs arithmetic (size_t)n + 1 without checking for integer overflow. On 32-bit systems, if n approaches SIZE_MAX (4GB), the addition overflows resulting in a small allocation while subsequent operations expect a much larger buffer.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `tools/bytecode/qjsc.c`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-003 scanner=multi_agent_ai -->
