### PR TITLE
Fast native calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # macOS
 .DS_Store
+.*code/
 
 # Editors
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ and this project adheres to [Semantic Versioning][semver].
 - Patch `0033`: defers interning non-constant bytecode atoms until they are
   first referenced, while preserving eager validation of their serialized
   lengths and boundaries.
+- Patch `0034`: dispatches interpreter-issued calls directly to supported
+  native functions while retaining the existing fallback for other callables.
 - The React Native runtime integration enables copied lazy loading; it is an
   integration change layered on top of patches `0031`–`0033`, not part of
   patch `0031` itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ and this project adheres to [Semantic Versioning][semver].
   accumulator while preserving iterator semantics for unsupported arrays.
 - Patch `0036`: forwards unchanged dense mapped arguments directly from their
   live parameter slots during apply, with the existing generic fallback.
+- Patch `0037`: avoids copying complete argument arrays for callees proven not
+  to write, capture, expose, or alias their argument slots.
 - The React Native runtime integration enables copied lazy loading; it is an
   integration change layered on top of patches `0031`–`0033`, not part of
   patch `0031` itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ and this project adheres to [Semantic Versioning][semver].
   native functions while retaining the existing fallback for other callables.
 - Patch `0035`: copies eligible dense array spreads directly into the
   accumulator while preserving iterator semantics for unsupported arrays.
+- Patch `0036`: forwards unchanged dense mapped arguments directly from their
+  live parameter slots during apply, with the existing generic fallback.
 - The React Native runtime integration enables copied lazy loading; it is an
   integration change layered on top of patches `0031`–`0033`, not part of
   patch `0031` itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ and this project adheres to [Semantic Versioning][semver].
   live parameter slots during apply, with the existing generic fallback.
 - Patch `0037`: avoids copying complete argument arrays for callees proven not
   to write, capture, expose, or alias their argument slots.
+- Patch `0038`: avoids reifying frame-visible arguments for safe length, indexed
+  access, and builtin apply patterns while preserving observable slow paths.
 - The React Native runtime integration enables copied lazy loading; it is an
   integration change layered on top of patches `0031`–`0033`, not part of
   patch `0031` itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog][keep-a-changelog],
 and this project adheres to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Changed
+- Patch `0034`: dispatches interpreter-issued calls directly to supported
+  native functions while retaining the existing fallback for other callables.
+- Patch `0035`: copies eligible dense array spreads directly into the
+  accumulator while preserving iterator semantics for unsupported arrays.
+- Patch `0036`: forwards unchanged dense mapped arguments directly from their
+  live parameter slots during apply, with the existing generic fallback.
+- Patch `0037`: avoids copying complete argument arrays for callees proven not
+  to write, capture, expose, or alias their argument slots.
+- Patch `0038`: avoids reifying frame-visible arguments for safe length, indexed
+  access, and builtin apply patterns while preserving observable slow paths.
+- Host-function calls now build only the arguments actually passed, instead of
+  materialising all eight inline slots, and the QuickJS value conversion is
+  inlined into the argument loop. Measured against the same branch without this
+  change, on-device release builds are 22–44% cheaper across arities 0, 1, 4 and
+  8 and for string- and object-backed arguments, with direct native and
+  JavaScript call controls unchanged.
+
+### Added
+- A JSI host-call benchmark in the example app, and a class-call row (the shape
+  a host function presents to the engine) in the `calls` benchmark suite.
+
 ## [v1.0.0-alpha.3] — 2026-09-10
 
 ### Added
@@ -95,16 +119,6 @@ and this project adheres to [Semantic Versioning][semver].
 - Patch `0033`: defers interning non-constant bytecode atoms until they are
   first referenced, while preserving eager validation of their serialized
   lengths and boundaries.
-- Patch `0034`: dispatches interpreter-issued calls directly to supported
-  native functions while retaining the existing fallback for other callables.
-- Patch `0035`: copies eligible dense array spreads directly into the
-  accumulator while preserving iterator semantics for unsupported arrays.
-- Patch `0036`: forwards unchanged dense mapped arguments directly from their
-  live parameter slots during apply, with the existing generic fallback.
-- Patch `0037`: avoids copying complete argument arrays for callees proven not
-  to write, capture, expose, or alias their argument slots.
-- Patch `0038`: avoids reifying frame-visible arguments for safe length, indexed
-  access, and builtin apply patterns while preserving observable slow paths.
 - The React Native runtime integration enables copied lazy loading; it is an
   integration change layered on top of patches `0031`–`0033`, not part of
   patch `0031` itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to [Semantic Versioning][semver].
   lengths and boundaries.
 - Patch `0034`: dispatches interpreter-issued calls directly to supported
   native functions while retaining the existing fallback for other callables.
+- Patch `0035`: copies eligible dense array spreads directly into the
+  accumulator while preserving iterator semantics for unsupported arrays.
 - The React Native runtime integration enables copied lazy loading; it is an
   integration change layered on top of patches `0031`–`0033`, not part of
   patch `0031` itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning][semver].
   to write, capture, expose, or alias their argument slots.
 - Patch `0038`: avoids reifying frame-visible arguments for safe length, indexed
   access, and builtin apply patterns while preserving observable slow paths.
+- Patch `0039`: keeps a pending exception when a formal parameter fails to
+  parse, instead of replacing a stack overflow, interrupt or allocation failure
+  with a syntax error.
 - Host-function calls now build only the arguments actually passed, instead of
   materialising all eight inline slots, and the QuickJS value conversion is
   inlined into the argument loop. Measured against the same branch without this

--- a/engine/patches/0034-native-call-dispatch.patch
+++ b/engine/patches/0034-native-call-dispatch.patch
@@ -1,0 +1,68 @@
+Subject: Dispatch Interpreter Calls Directly To Native Functions
+
+What this does
+  Directly dispatches eligible interpreter-issued calls to non-bytecode functions
+  from the OP_call and OP_call_method handlers.
+
+Why we need it
+  A native call does not need the interpreter activation that JS_CallInternal()
+  prepares for a bytecode function. The direct path avoids that unused
+  activation while retaining the existing call semantics.
+
+What it adds
+  The helper preserves interrupt polling, the existing this value and argument
+  array, realm handling, exception propagation, tail-call behavior, and the slow
+  path for bytecode, non-callable, and unsupported values.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -19310,6 +19310,28 @@
+     return can_store_error_stack(exc) || can_add_backtrace(exc);
+ }
+ 
++static inline int js_call_c_function_fast(
++    JSContext *ctx, JSValueConst func_obj, JSValueConst this_obj, int argc,
++    JSValueConst *argv, int flags, JSValue *pret)
++{
++    JSObject *p;
++    JSClassCall *call_func;
++
++    if (unlikely(JS_VALUE_GET_TAG(func_obj) != JS_TAG_OBJECT))
++        return 0;
++    p = JS_VALUE_GET_OBJ(func_obj);
++    if (p->class_id == JS_CLASS_BYTECODE_FUNCTION)
++        return 0;
++    call_func = ctx->rt->class_array[p->class_id].call;
++    if (unlikely(!call_func))
++        return 0;
++    if (unlikely(js_poll_interrupts(ctx)))
++        *pret = JS_EXCEPTION;
++    else
++        *pret = call_func(ctx, func_obj, this_obj, argc, argv, flags);
++    return 1;
++}
++
+ /* argv[] is modified if (flags & JS_CALL_FLAG_COPY_ARGV) = 0. */
+ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
+                                JSValueConst this_obj, JSValueConst new_target,
+@@ -19896,6 +19923,8 @@
+             has_call_argc:
+                 call_argv = sp - call_argc;
+                 sf->cur_pc = pc;
++                if (!js_call_c_function_fast(ctx, call_argv[-1], JS_UNDEFINED, call_argc,
++                                             vc(call_argv), 0, &ret_val))
+                 ret_val = JS_CallInternal(ctx, call_argv[-1], JS_UNDEFINED,
+                                           JS_UNDEFINED, call_argc,
+                                           vc(call_argv), 0);
+@@ -19933,6 +19964,8 @@
+                 pc += 2;
+                 call_argv = sp - call_argc;
+                 sf->cur_pc = pc;
++                if (!js_call_c_function_fast(ctx, call_argv[-1], call_argv[-2], call_argc,
++                                             vc(call_argv), 0, &ret_val))
+                 ret_val = JS_CallInternal(ctx, call_argv[-1], call_argv[-2],
+                                           JS_UNDEFINED, call_argc,
+                                           vc(call_argv), 0);

--- a/engine/patches/0035-dense-array-spread-fast-path.patch
+++ b/engine/patches/0035-dense-array-spread-fast-path.patch
@@ -1,0 +1,84 @@
+Subject: Optimize Dense Array Spread Calls
+
+What this does
+  Adds a fast path for spreads of dense ordinary arrays whose builtin array
+  iterator and iterator next method are unchanged. It copies the source
+  elements directly into the spread accumulator.
+
+Why we need it
+  The generic spread path creates and inspects an iterator before discovering
+  that a dense array can be copied directly. It also uses the general property
+  API even when the accumulator is a fresh dense array.
+
+What it adds
+  The fast path checks the iterator methods, source length, source storage,
+  and accumulator layout before allocating the iterator. It grows the
+  accumulator once, duplicates each source value into its final slot, updates
+  the length, and falls back to the existing iterator path for sparse, altered,
+  proxied, exotic, or otherwise unsupported cases.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -18615,6 +18615,54 @@
+                                        JS_ITERATOR_KIND_VALUE);
+     JS_FreeValue(ctx, iterator);
+
++    /* Used to squelch a -Wcast-function-type warning. */
++    JSCFunctionType ft2 = { .iterator_next = js_array_iterator_next };
++    if (is_array_iterator) {
++        JSPropertyDescriptor desc;
++        JSValue *src_arr;
++        uint32_t src_count, src_len;
++        JSObject *dst;
++        int ret;
++
++        ret = JS_GetOwnProperty(ctx, &desc,
++                                ctx->class_proto[JS_CLASS_ARRAY_ITERATOR],
++                                JS_ATOM_next);
++        if (ret < 0)
++            return -1;
++        if (ret > 0 && !(desc.flags & JS_PROP_GETSET)) {
++            bool next_ok = JS_IsCFunction(ctx, desc.value, ft2.generic, 0);
++            if (next_ok && js_get_fast_array(ctx, sp[-1], &src_arr, &src_count)) {
++                if (!js_get_length32(ctx, &src_len, sp[-1]) &&
++                    js_get_fast_array(ctx, sp[-1], &src_arr, &src_count) &&
++                    src_len == src_count) {
++                    dst = JS_VALUE_GET_OBJ(sp[-3]);
++                    if (dst->class_id == JS_CLASS_ARRAY && dst->fast_array &&
++                        dst->u.array.count == pos &&
++                        JS_VALUE_GET_TAG(dst->prop[0].u.value) == JS_TAG_INT &&
++                        (get_shape_prop(dst->shape)->flags & JS_PROP_WRITABLE)) {
++                        uint32_t k, new_count = pos + src_count;
++                        if (new_count >= pos) {
++                            if (new_count > dst->u.array.u1.size &&
++                                expand_fast_array(ctx, dst, new_count)) {
++                                js_free_desc(ctx, &desc);
++                                return -1;
++                            }
++                            for (k = 0; k < src_count; k++)
++                                dst->u.array.u.values[pos + k] = js_dup(src_arr[k]);
++                            dst->u.array.count = new_count;
++                            dst->prop[0].u.value = js_int32(new_count);
++                            sp[-2] = js_int32(new_count);
++                            js_free_desc(ctx, &desc);
++                            return 0;
++                        }
++                    }
++                }
++            }
++        }
++        if (ret > 0)
++            js_free_desc(ctx, &desc);
++    }
++
+     enumobj = JS_GetIterator(ctx, sp[-1], false);
+     if (JS_IsException(enumobj))
+         return -1;
+@@ -18727,4 +18774,2 @@
+     }
+-    /* Used to squelch a -Wcast-function-type warning. */
+-    JSCFunctionType ft2 = { .iterator_next = js_array_iterator_next };
+     if (is_array_iterator

--- a/engine/patches/0036-mapped-arguments-fast-copy.patch
+++ b/engine/patches/0036-mapped-arguments-fast-copy.patch
@@ -1,0 +1,38 @@
+Subject: Copy Mapped Arguments Without Property Lookups
+
+What this does
+  Adds a fast path for mapped arguments objects passed to
+  Function.prototype.apply, Reflect.apply, and Reflect.construct. When the
+  arguments object is still a dense fast array with its original length, the
+  values are duplicated directly from the live variable-reference slots.
+
+Why we need it
+  Mapped arguments expose parameter slots through JSVarRef entries, but the
+  generic apply path reads each element through the arguments exotic property
+  lookup. The lookup is unnecessary while the object remains dense and
+  unmodified.
+
+What it adds
+  The fast path admits only the unchanged dense mapped-arguments representation
+  and duplicates each referenced value into the existing argument buffer.
+  Deleted or redefined elements, changed length, sparse data, proxies, and all
+  other cases continue through the existing property-based path.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -46142,6 +46142,12 @@ static JSValue *build_arg_list(JSContext *ctx, uint32_t *plen,
+         for(i = 0; i < len; i++) {
+             tab[i] = js_dup(p->u.array.u.values[i]);
+         }
++    } else if (p->class_id == JS_CLASS_MAPPED_ARGUMENTS &&
++               p->fast_array &&
++               len == p->u.array.count) {
++        for(i = 0; i < len; i++) {
++            tab[i] = js_dup(*p->u.array.u.var_refs[i]->pvalue);
++        }
+     } else {
+         for(i = 0; i < len; i++) {
+             ret = JS_GetPropertyUint32(ctx, array_arg, i);

--- a/engine/patches/0037-argv-safe-argument-copy-elision.patch
+++ b/engine/patches/0037-argv-safe-argument-copy-elision.patch
@@ -1,0 +1,132 @@
+Subject: Elide Safe Argument Copies For Read-Only Callees
+
+What this does
+  Adds a compiler proof that marks a function when its bytecode cannot
+  write, capture, expose, or alias an argument slot. When such a function is
+  called with JS_CALL_FLAG_COPY_ARGV and receives all declared arguments, the
+  caller's argument array is used directly instead of being duplicated into a
+  second value buffer.
+
+Why we need it
+  COPY_ARGV protects callers from callees that write argument slots. Functions
+  that only read their arguments already provide that property, but the normal
+  call path still allocates and fills a private buffer. Such functions can use
+  the caller's values without changing observable argument behavior.
+
+What it adds
+  A conservative bytecode scan rejects parameter writes, all current short and
+  general argument-write opcodes, argument references, eval, apply-eval, and
+  mapped arguments creation. It runs after final compilation and during shared
+  bytecode-body validation, covering eager and lazy deserialization. Unknown or
+  malformed instruction streams leave the bit clear, preserving the existing
+  copy behavior.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -42374,1 +42374,44 @@ static JSString *JS_ReadString(BCReaderState *s);
+ static JSString *JS_ReadString(BCReaderState *s);
++static bool js_argv_safe_opcode(const uint8_t *bc, int pos, int op)
++{
++    switch (op) {
++    case OP_put_arg:  case OP_set_arg:
++    case OP_put_arg0: case OP_set_arg0:
++    case OP_put_arg1: case OP_set_arg1:
++    case OP_put_arg2: case OP_set_arg2:
++    case OP_put_arg3: case OP_set_arg3:
++    case OP_make_arg_ref:
++    case OP_eval:     case OP_apply_eval:
++    case OP_get_arg_el:
++    case OP_apply_arguments:
++        return false;
++    case OP_special_object:
++        return bc[pos + 1] != OP_SPECIAL_OBJECT_MAPPED_ARGUMENTS;
++    default:
++        return true;
++    }
++}
++
++static void js_scan_argv_safe(JSFunctionBytecode *b)
++{
++    const uint8_t *bc;
++    int pos = 0, len;
++
++    if (b == NULL)
++        return;
++    bc = b->byte_code_buf;
++    len = b->byte_code_len;
++    if (bc == NULL || len <= 0)
++        return;
++
++    while (pos < len) {
++        int op = bc[pos];
++        int sz = short_opcode_info(op).size;
++        if (sz <= 0 || pos + sz > len)
++            return;
++        if (!js_argv_safe_opcode(bc, pos, op))
++            return;
++        pos += sz;
++    }
++    b->argv_safe = 1;
++}
+@@ -42471,5 +42473,6 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
+ {
+     uint8_t *bc_buf;
+     int pos, len, op;
++    bool argv_safe = true;
+     JSAtom atom;
+     uint32_t idx;
+@@ -42490,4 +42493,6 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
+             b->byte_code_len = pos;
+             return -1;
+         }
++        if (!js_argv_safe_opcode(bc_buf, pos, op))
++            argv_safe = false;
+         switch(short_opcode_info(op).fmt) {
+@@ -42522,4 +42527,5 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
+         pos += len;
+     }
++    b->argv_safe = argv_safe;
+     return 0;
+ }
+@@ -39458,1 +39458,3 @@ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
++static void js_scan_argv_safe(JSFunctionBytecode *b);
++
+ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
+@@ -39918,5 +39920,6 @@
+     b->byte_code_buf = (void *)((uint8_t*)b + byte_code_offset);
+     b->byte_code_len = fd->byte_code.size;
+     memcpy(b->byte_code_buf, fd->byte_code.buf, fd->byte_code.size);
++    js_scan_argv_safe(b);
+     js_free(ctx, fd->byte_code.buf);
+     fd->byte_code.buf = NULL;
+@@ -1010,7 +1010,7 @@
+        filled and cannot be re-parsed, so every later call has to fail rather
+        than run with a NULL byte_code_buf. */
+     uint8_t lazy_failed : 1;
+-    /* XXX: 2 bits available */
++    uint8_t argv_safe : 1;
+     uint8_t *byte_code_buf; /* (self pointer) */
+     int byte_code_len;
+     /* Runtime-only unified IC storage. It is allocated on first successful fill. */
+@@ -19162,6 +19163,8 @@
+ }
+ 
+ #define JS_CALL_FLAG_COPY_ARGV   (1 << 1)
++
++#define JS_ARGV_SAFE(b) ((b)->argv_safe)
+ #define JS_CALL_FLAG_GENERATOR   (1 << 2)
+ 
+ static JSValue js_call_c_function(JSContext *ctx, JSValueConst func_obj,
+@@ -19474,7 +19481,8 @@
+             return JS_EXCEPTION;
+     }
+ 
+-    if (unlikely(argc < b->arg_count || (flags & JS_CALL_FLAG_COPY_ARGV))) {
++    if (unlikely(argc < b->arg_count ||
++                 ((flags & JS_CALL_FLAG_COPY_ARGV) && !JS_ARGV_SAFE(b)))) {
+         arg_allocated_size = b->arg_count;
+     } else {
+         arg_allocated_size = 0;

--- a/engine/patches/0038-arguments-reification-elision.patch
+++ b/engine/patches/0038-arguments-reification-elision.patch
@@ -1,0 +1,460 @@
+Subject: Avoid Reifying Frame-Visible Arguments
+
+What this does
+  Adds a compiler and interpreter optimization for functions whose arguments
+  uses can be answered directly from the active call frame.
+  Length reads use the current argument count, indexed reads use the live
+  argument slots when the key is an in-range integer, and an unchanged
+  Function.prototype.apply call can invoke the target with the frame arguments
+  without first constructing an arguments object.
+
+Why we need it
+  Referencing arguments currently allocates and initializes an arguments object
+  even when the function only reads its length, reads mapped parameter values,
+  or forwards the values through the builtin apply method. Those allocations,
+  variable-reference entries, and copies are avoidable for these non-escaping
+  patterns.
+
+What it adds
+  A conservative pass-2 scan rejects captured or aliased arguments, direct eval,
+  variable-object access, writes, unknown consumers, non-mapped snapshot cases,
+  and control-flow shapes it cannot model. Accepted sites are marked in place
+  Complex indexed expressions use a conservative linear stack-depth walk and
+  remain on the ordinary path when the walk cannot prove their consumer.
+  and use cold helpers to memoize a real arguments object whenever a slow path
+  is required. Runtime identity checks preserve replaced apply methods, proxies,
+  accessors, out-of-range keys, iterator behavior, exceptions, and cross-realm
+  errors. The transformation is part of the normal compiler output.
+
+Needs a bytecode version bump
+  Yes
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -3264,1 +3264,5 @@
++static JSValue js_build_arguments(JSContext *ctx, int argc, JSValueConst *argv);
++static JSValue js_build_mapped_arguments(JSContext *ctx, int argc,
++                                         JSValueConst *argv, JSStackFrame *sf,
++                                         int arg_count);
+ int JS_GetLocalVariablesAtLevel(JSContext *ctx, int level,
+@@ -3310,1 +3310,18 @@
+     int idx = 0;
++    for (int i = 0; i < b->var_count; i++) {
++        if (b->vardefs[b->arg_count + i].var_name == JS_ATOM_arguments &&
++            JS_VALUE_GET_TAG(sf->var_buf[i]) != JS_TAG_OBJECT) {
++            JSValue arguments;
++            if (b->is_strict_mode || !b->has_simple_parameter_list)
++                arguments = js_build_arguments(ctx, sf->arg_count, sf->arg_buf);
++            else
++                arguments = js_build_mapped_arguments(ctx, sf->arg_count,
++                                                      sf->arg_buf, sf,
++                                                      min_int(sf->arg_count,
++                                                              b->arg_count));
++            if (JS_IsException(arguments))
++                goto fail;
++            sf->var_buf[i] = arguments;
++            break;
++        }
++    }
+@@ -1526,6 +1526,7 @@
+ 
+ static JSValue js_function_apply(JSContext *ctx, JSValueConst this_val,
+                                  int argc, JSValueConst *argv, int magic);
++static int check_function(JSContext *ctx, JSValueConst obj);
+ static void js_array_finalizer(JSRuntime *rt, JSValueConst val);
+ static void js_array_mark(JSRuntime *rt, JSValueConst val,
+                           JS_MarkFunc *mark_func);
+@@ -18021,6 +18066,58 @@
+     return JS_EXCEPTION;
+ }
+ 
++static JSObject *js_args_apply_is_builtin(JSValueConst v)
++{
++    JSObject *p;
++    if (JS_VALUE_GET_TAG(v) != JS_TAG_OBJECT)
++        return NULL;
++    p = JS_VALUE_GET_OBJ(v);
++    if (p->class_id == JS_CLASS_C_FUNCTION &&
++        p->u.cfunc.cproto == JS_CFUNC_generic_magic &&
++        p->u.cfunc.c_function.generic_magic == js_function_apply &&
++        p->u.cfunc.magic == 0)
++        return p;
++    return NULL;
++}
++
++static no_inline JSValue js_args_memo(JSContext *ctx, JSValue *slot,
++                                      int argc, JSValueConst *argv,
++                                      JSStackFrame *sf, int arg_count)
++{
++    JSValue v;
++    if (likely(JS_VALUE_GET_TAG(*slot) != JS_TAG_UNINITIALIZED))
++        return *slot;
++    v = js_build_mapped_arguments(ctx, argc, argv, sf, min_int(argc, arg_count));
++    if (unlikely(JS_IsException(v)))
++        return JS_EXCEPTION;
++    *slot = v;
++    return v;
++}
++
++static no_inline JSValue js_args_el_slow(JSContext *ctx, JSValue *slot,
++                                        JSValue key, int argc,
++                                        JSValueConst *argv, JSStackFrame *sf,
++                                        int arg_count)
++{
++    JSValue ao = js_args_memo(ctx, slot, argc, argv, sf, arg_count);
++    if (unlikely(JS_IsException(ao)))
++        return JS_EXCEPTION;
++    return JS_GetPropertyValue(ctx, ao, key);
++}
++
++static no_inline JSValue js_args_apply_reified(JSContext *ctx, JSValue *slot,
++                                               JSValue *st, int argc,
++                                               JSValueConst *argv, JSStackFrame *sf,
++                                               int arg_count)
++{
++    JSValue args2[2];
++    JSValue ao = js_args_memo(ctx, slot, argc, argv, sf, arg_count);
++    if (unlikely(JS_IsException(ao)))
++        return JS_EXCEPTION;
++    args2[0] = st[2];
++    args2[1] = ao;
++    return JS_Call(ctx, st[1], st[0], 2, vc(args2));
++}
+ static JSValue build_for_in_iterator(JSContext *ctx, JSValue obj)
+ {
+     JSObject *p;
+@@ -19345,6 +19511,7 @@
+     OP_SPECIAL_OBJECT_VAR_OBJECT,
+     OP_SPECIAL_OBJECT_IMPORT_META,
+     OP_SPECIAL_OBJECT_NULL_PROTO,
++    OP_SPECIAL_OBJECT_ARG_COUNT,
+ } OPSpecialObjectEnum;
+ 
+ #define FUNC_RET_AWAIT      0
+@@ -19796,6 +19969,9 @@
+                     *sp++ = JS_NewObjectProtoClass(ctx, JS_NULL, JS_CLASS_OBJECT);
+                     if (unlikely(JS_IsException(sp[-1])))
+                         goto exception;
++                    break;
++                case OP_SPECIAL_OBJECT_ARG_COUNT:
++                    *sp++ = js_int32(argc);
+                     break;
+                 default:
+                     abort();
+@@ -20059,6 +20240,52 @@
+                 sf->cur_pc = pc;
+ 
+                 ret_val = js_function_apply(ctx, sp[-3], 2, vc(&sp[-2]), magic);
++                if (unlikely(JS_IsException(ret_val)))
++                    goto exception;
++                JS_FreeValue(ctx, sp[-3]);
++                JS_FreeValue(ctx, sp[-2]);
++                JS_FreeValue(ctx, sp[-1]);
++                sp -= 3;
++                *sp++ = ret_val;
++            }
++            BREAK;
++
++        CASE(OP_get_arg_el):
++            {
++                int idx = get_u16(pc);
++                pc += 2;
++                if (likely(JS_VALUE_GET_TAG(sp[-1]) == JS_TAG_INT)) {
++                    uint32_t i = (uint32_t)JS_VALUE_GET_INT(sp[-1]);
++                    if (likely(i < (uint32_t)argc)) {
++                        sp[-1] = js_dup(i < (uint32_t)b->arg_count
++                                        ? arg_buf[i] : argv[i]);
++                        BREAK;
++                    }
++                }
++                sf->cur_pc = pc;
++                ret_val = js_args_el_slow(ctx, &var_buf[idx], sp[-1], argc, argv,
++                                          sf, b->arg_count);
++                if (unlikely(JS_IsException(ret_val)))
++                    goto exception;
++                sp[-1] = ret_val;
++            }
++            BREAK;
++
++        CASE(OP_apply_arguments):
++            {
++                int idx = get_u16(pc);
++                pc += 2;
++                sf->cur_pc = pc;
++                JSObject *pa = js_args_apply_is_builtin(sp[-2]);
++                if (likely(pa != NULL &&
++                           (arg_buf == (JSValue *)argv || argc <= b->arg_count))) {
++                    if (unlikely(check_function(pa->u.cfunc.realm, sp[-3])))
++                        goto exception;
++                    ret_val = JS_Call(ctx, sp[-3], sp[-1], argc, vc(arg_buf));
++                } else {
++                    ret_val = js_args_apply_reified(ctx, &var_buf[idx], sp - 3,
++                                                 argc, argv, sf, b->arg_count);
++                }
+                 if (unlikely(JS_IsException(ret_val)))
+                     goto exception;
+                 JS_FreeValue(ctx, sp[-3]);
+@@ -20571,8 +20848,6 @@
+         CASE(OP_get_var_ref2): *sp++ = js_dup(*var_refs[2]->pvalue); BREAK;
+         CASE(OP_get_var_ref3): *sp++ = js_dup(*var_refs[3]->pvalue); BREAK;
+         CASE(OP_put_var_ref0): set_value(ctx, var_refs[0]->pvalue, *--sp); BREAK;
+-        CASE(OP_put_var_ref1): set_value(ctx, var_refs[1]->pvalue, *--sp); BREAK;
+-        CASE(OP_put_var_ref2): set_value(ctx, var_refs[2]->pvalue, *--sp); BREAK;
+         CASE(OP_put_var_ref3): set_value(ctx, var_refs[3]->pvalue, *--sp); BREAK;
+         CASE(OP_set_var_ref0): set_value(ctx, var_refs[0]->pvalue, js_dup(sp[-1])); BREAK;
+         CASE(OP_set_var_ref1): set_value(ctx, var_refs[1]->pvalue, js_dup(sp[-1])); BREAK;
+@@ -38161,8 +38442,11 @@
+             dbuf_putc(bc_out, OP_get_var_ref0 + idx);
+             return;
+         case OP_put_var_ref:
+-            dbuf_putc(bc_out, OP_put_var_ref0 + idx);
+-            return;
++            if (idx == 0) {
++                dbuf_putc(bc_out, OP_put_var_ref0);
++                return;
++            }
++            break;
+         case OP_set_var_ref:
+             dbuf_putc(bc_out, OP_set_var_ref0 + idx);
+             return;
+@@ -38192,6 +38485,128 @@
+ }
+ 
+ /* peephole optimizations and resolve goto/labels */
++
++enum {
++    JS_ARGS_KIND_NONE,
++    JS_ARGS_KIND_LENGTH,
++    JS_ARGS_KIND_ELEM,
++    JS_ARGS_KIND_APPLY,
++};
++
++static int js_args_find_elem_load(const uint8_t *bc_buf, int bc_len, int pos_next)
++{
++    int pos, op, len, depth = 1;
++    const JSOpCode *oi;
++
++    for (pos = pos_next; pos < bc_len; pos += len) {
++        op = bc_buf[pos];
++        oi = &opcode_info[op];
++        len = oi->size;
++        if (len <= 0 || pos + len > bc_len)
++            return -1;
++        if (op == OP_get_array_el && depth == 2)
++            return pos;
++        switch (oi->fmt) {
++        case OP_FMT_label:
++        case OP_FMT_label8:
++        case OP_FMT_label16:
++        case OP_FMT_label_u16:
++        case OP_FMT_atom_label_u8:
++        case OP_FMT_atom_label_u16:
++        case OP_FMT_npop:
++        case OP_FMT_npopx:
++        case OP_FMT_npop_u16:
++            return -1;
++        default:
++            break;
++        }
++        switch (op) {
++        case OP_label:
++        case OP_with_get_var:   case OP_with_delete_var:
++        case OP_with_make_ref:  case OP_with_get_ref:
++        case OP_with_get_ref_undef: case OP_with_put_var:
++        case OP_catch:          case OP_nip_catch:
++        case OP_for_of_start:   case OP_for_await_of_start:
++        case OP_iterator_close:
++        case OP_drop:           case OP_nip:  case OP_nip1:
++        case OP_return:         case OP_return_undef:
++        case OP_return_async:   case OP_throw: case OP_throw_error:
++        case OP_ret:            case OP_gosub:
++            return -1;
++        default:
++            break;
++        }
++        depth += (int)oi->n_push - (int)oi->n_pop;
++        if (depth < 1)
++            return -1;
++    }
++    return -1;
++}
++
++static int js_args_site_kind(CodeContext *cc, int pos_next, bool mapped, int *pel)
++{
++    int el;
++    if (code_match(cc, pos_next, OP_get_field, -1))
++        return cc->atom == JS_ATOM_length ? JS_ARGS_KIND_LENGTH
++                                          : JS_ARGS_KIND_NONE;
++    if (!mapped)
++        return JS_ARGS_KIND_NONE;
++    if (code_match(cc, pos_next, OP_call_method, 2, -1))
++        return JS_ARGS_KIND_APPLY;
++    el = js_args_find_elem_load(cc->bc_buf, cc->bc_len, pos_next);
++    if (el >= 0) {
++        *pel = el;
++        return JS_ARGS_KIND_ELEM;
++    }
++    return JS_ARGS_KIND_NONE;
++}
++
++static int js_args_elide_scan(JSFunctionDef *s, uint8_t *bc_buf, int bc_len,
++                              bool mapped, bool mark)
++{
++    CodeContext cc;
++    int pos, op, len, fmt, A, kinds = 0;
++
++    A = s->arguments_var_idx;
++    if (A < 0 || A >= s->var_count)
++        return -1;
++    if (s->arguments_arg_idx >= 0 || s->has_eval_call ||
++        s->var_object_idx >= 0 || s->arg_var_object_idx >= 0) {
++        return -1;
++    }
++    if (s->vars[A].is_captured) {
++        return -1;
++    }
++    cc.bc_buf = bc_buf;
++    cc.bc_len = bc_len;
++    for (pos = 0; pos < bc_len; pos += len) {
++        int kind, el = -1;
++        op = bc_buf[pos];
++        len = opcode_info[op].size;
++        if (len <= 0)
++            return -1;
++        fmt = opcode_info[op].fmt;
++        if (fmt == OP_FMT_none_loc || fmt == OP_FMT_loc8)
++            return -1;
++        if (fmt != OP_FMT_loc)
++            continue;
++        if (get_u16(bc_buf + pos + 1) != A)
++            continue;
++        if (op != OP_get_loc)
++            return -1;
++        kind = js_args_site_kind(&cc, pos + len, mapped, &el);
++        if (kind == JS_ARGS_KIND_NONE)
++            return -1;
++        kinds |= 1 << kind;
++        if (mark) {
++            bc_buf[pos] = OP_args_recv;
++            put_u16(bc_buf + pos + 1, kind);
++            if (kind == JS_ARGS_KIND_ELEM)
++                bc_buf[el] = OP_args_el;
++        }
++    }
++    return kinds;
++}
+ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
+ {
+     int pos, pos_next, bc_len, op, op1, len, i, line_num, col_num, patch_offsets;
+@@ -38205,6 +38791,7 @@
+     int objlit_k = 0;
+     int objlit_live_count = 0;
+     int objlit_template_index;
++    int args_elide_kinds = -1;
+ 
+     label_slots = s->label_slots;
+ 
+@@ -38228,6 +38815,26 @@
+         s->line_number_last = s->line_num;
+         s->col_number_last = s->col_num;
+         s->line_number_last_pc = 0;
++    }
++
++    if (s->arguments_var_idx >= 0) {
++        bool mapped = !s->is_strict_mode && s->has_simple_parameter_list;
++        args_elide_kinds = js_args_elide_scan(s, (uint8_t *)bc_buf, bc_len,
++                                              mapped, false);
++        if (args_elide_kinds >= 0) {
++            js_args_elide_scan(s, (uint8_t *)bc_buf, bc_len, mapped, true);
++            if (mapped && (args_elide_kinds &
++                           ((1 << JS_ARGS_KIND_ELEM) |
++                            (1 << JS_ARGS_KIND_APPLY)))) {
++                for (i = 0; i < s->arg_count; i++)
++                    capture_var(s, &s->args[i]);
++            }
++            if (args_elide_kinds &
++                ((1 << JS_ARGS_KIND_ELEM) | (1 << JS_ARGS_KIND_APPLY))) {
++                dbuf_putc(&bc_out, OP_set_loc_uninitialized);
++                dbuf_put_u16(&bc_out, s->arguments_var_idx);
++            }
++        }
+     }
+ 
+     /* initialize the 'home_object' variable if needed */
+@@ -38260,7 +38887,7 @@
+         }
+     }
+     /* initialize the 'arguments' variable if needed */
+-    if (s->arguments_var_idx >= 0) {
++    if (s->arguments_var_idx >= 0 && args_elide_kinds < 0) {
+         if (s->is_strict_mode || !s->has_simple_parameter_list) {
+             dbuf_putc(&bc_out, OP_special_object);
+             dbuf_putc(&bc_out, OP_SPECIAL_OBJECT_ARGUMENTS);
+@@ -38827,6 +39454,49 @@
+                 break;
+             }
+             goto no_change;
++        case OP_args_recv:
++            {
++                int kind = get_u16(bc_buf + pos + 1);
++                assert(args_elide_kinds >= 0);
++                switch (kind) {
++                case JS_ARGS_KIND_LENGTH:
++                    /* Removing get_field(length) requires releasing its atom. */
++                    if (!code_match(&cc, pos_next, OP_get_field, -1) ||
++                        cc.atom != JS_ATOM_length)
++                        goto args_elide_desync;
++                    JS_FreeAtom(ctx, cc.atom);
++                    if (cc.line_num >= 0) line_num = cc.line_num;
++                    if (cc.col_num >= 0) col_num = cc.col_num;
++                    add_pc2line_info(s, bc_out.size, line_num, col_num);
++                    dbuf_putc(&bc_out, OP_special_object);
++                    dbuf_putc(&bc_out, OP_SPECIAL_OBJECT_ARG_COUNT);
++                    pos_next = cc.pos;
++                    break;
++                case JS_ARGS_KIND_APPLY:
++                    if (!code_match(&cc, pos_next, OP_call_method, 2, -1))
++                        goto args_elide_desync;
++                    if (cc.line_num >= 0) line_num = cc.line_num;
++                    if (cc.col_num >= 0) col_num = cc.col_num;
++                    add_pc2line_info(s, bc_out.size, line_num, col_num);
++                    dbuf_putc(&bc_out, OP_apply_arguments);
++                    dbuf_put_u16(&bc_out, s->arguments_var_idx);
++                    pos_next = cc.pos;
++                    break;
++                case JS_ARGS_KIND_ELEM:
++                    break;
++                default:
++                args_elide_desync:
++                    JS_ThrowInternalError(ctx, "arguments elision desync (kind=%d, pos=%d)",
++                                          kind, pos);
++                    goto fail;
++                }
++            }
++            break;
++        case OP_args_el:
++            add_pc2line_info(s, bc_out.size, line_num, col_num);
++            dbuf_putc(&bc_out, OP_get_arg_el);
++            dbuf_put_u16(&bc_out, s->arguments_var_idx);
++            break;
+ 
+         case OP_get_loc:
+             {
+--- a/quickjs-opcode.h
++++ b/quickjs-opcode.h
+@@ -315,1 +315,4 @@
+ def(     debug_stmt, 2, 0, 0, u8) /* emitted in phase 1, removed in phase 3 */
++
++def(      args_recv, 3, 0, 1, u16)
++def(        args_el, 1, 2, 1, none)
+@@ -364,8 +389,8 @@
+ DEF(   get_var_ref2, 1, 0, 1, none_var_ref)
+ DEF(   get_var_ref3, 1, 0, 1, none_var_ref)
+ DEF(   put_var_ref0, 1, 1, 0, none_var_ref)
+-DEF(   put_var_ref1, 1, 1, 0, none_var_ref)
+-DEF(   put_var_ref2, 1, 1, 0, none_var_ref)
++DEF(     get_arg_el, 3, 1, 1, loc)
++DEF(apply_arguments, 3, 3, 1, loc)
+ DEF(   put_var_ref3, 1, 1, 0, none_var_ref)
+ DEF(   set_var_ref0, 1, 1, 1, none_var_ref)
+ DEF(   set_var_ref1, 1, 1, 1, none_var_ref)

--- a/engine/patches/0039-pending-exception-wins-over-syntax-error.patch
+++ b/engine/patches/0039-pending-exception-wins-over-syntax-error.patch
@@ -1,0 +1,35 @@
+Subject: Keep A Pending Exception When A Formal Parameter Fails To Parse
+
+What this does
+  When the formal-parameter loop meets a token that is not a parameter name,
+  it first checks whether an exception is already pending and, if so, lets it
+  propagate instead of replacing it with "missing formal parameter".
+
+Why we need it
+  A stack overflow, interrupt or allocation failure raised while reading that
+  token is the real error. Overwriting it with a syntax error hides the cause
+  and makes the failure the embedder sees depend on how deep the native stack
+  happened to be when the parser was reached -- which varies with code layout
+  and target, not with anything the program did.
+
+What it adds
+  One JS_HasException() guard in the parameter loop. No opcode, bytecode or
+  API change.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -40570,6 +40570,11 @@
+                     }
+                 }
+             } else {
++                /* A pending exception (stack overflow, interrupt, OOM) set while
++                   reading this token is the real error; reporting a syntax error
++                   here would replace it and hide what actually happened. */
++                if (JS_HasException(s->ctx))
++                    goto fail;
+                 js_parse_error(s, "missing formal parameter");
+                 goto fail;
+             }

--- a/engine/patches/9999-bc-version-bump.patch
+++ b/engine/patches/9999-bc-version-bump.patch
@@ -22,6 +22,7 @@ Why we need it
     0015-inline-caches       adds opcodes and serialized IC metadata
     0030-crc32c-bytecode-checksum changes the checksum encoding
     0031-lazy-bytecode-function-bodies changes the serialized function layout
+    0038-arguments-reification-elision changes emitted argument-use opcodes
 
   A patch that needs the version raised says so in its own header and in its
   row of README.md, and changes nothing itself.

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -47,6 +47,7 @@ what we changed and why without opening a single `.patch` file.
 | `0034` | Dispatches interpreter-issued calls to native functions without an interpreter activation | Native calls otherwise enter the bytecode-call machinery before reaching the same class call entry, adding setup and argument spill work that is unnecessary for non-bytecode callees | - | No |
 | `0035` | Copies eligible dense array spreads directly into the argument accumulator | Unchanged builtin array iterators otherwise allocate an iterator and route every element through general property definition before the call | - | No |
 | `0036` | Copies unchanged dense mapped arguments directly from their live variable-reference slots during apply | Avoids one exotic property lookup per forwarded argument while preserving the generic path for modified or sparse arguments objects | - | No |
+| `0037` | Skips COPY_ARGV materialization for functions proven not to write or retain argument slots | Callback callees that only read their arguments can reuse the caller's complete argument array without allocation or duplication | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -46,6 +46,7 @@ what we changed and why without opening a single `.patch` file.
 | `0033` | Defers atom interning for lazy bytecode entries until first use | Cold Metro function bodies need not construct their string and symbol atoms during startup; entries are validated, memoized, and shared when materialized | - | No |
 | `0034` | Dispatches interpreter-issued calls to native functions without an interpreter activation | Native calls otherwise enter the bytecode-call machinery before reaching the same class call entry, adding setup and argument spill work that is unnecessary for non-bytecode callees | - | No |
 | `0035` | Copies eligible dense array spreads directly into the argument accumulator | Unchanged builtin array iterators otherwise allocate an iterator and route every element through general property definition before the call | - | No |
+| `0036` | Copies unchanged dense mapped arguments directly from their live variable-reference slots during apply | Avoids one exotic property lookup per forwarded argument while preserving the generic path for modified or sparse arguments objects | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -49,6 +49,7 @@ what we changed and why without opening a single `.patch` file.
 | `0036` | Copies unchanged dense mapped arguments directly from their live variable-reference slots during apply | Avoids one exotic property lookup per forwarded argument while preserving the generic path for modified or sparse arguments objects | - | No |
 | `0037` | Skips COPY_ARGV materialization for functions proven not to write or retain argument slots | Callback callees that only read their arguments can reuse the caller's complete argument array without allocation or duplication | - | No |
 | `0038` | Avoids reifying frame-visible mapped arguments for length, indexed reads, and verified builtin apply calls | Non-escaping argument uses can read the active frame without allocating an arguments object, while all observable slow paths retain the ordinary object | - | Yes |
+| `0039` | Keeps a pending exception when a formal parameter fails to parse | A stack overflow, interrupt or allocation failure raised while reading the parameter token is the real error; replacing it with "missing formal parameter" hides the cause and makes the reported failure depend on native stack depth | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -45,6 +45,7 @@ what we changed and why without opening a single `.patch` file.
 | `0032` | Adds explicit caller-owned borrowed storage for lazy bytecode input | Embedders with stable immutable storage can avoid the engine-owned payload copy without changing the safe copied-lazy default | `JS_READ_OBJ_BORROW` | No |
 | `0033` | Defers atom interning for lazy bytecode entries until first use | Cold Metro function bodies need not construct their string and symbol atoms during startup; entries are validated, memoized, and shared when materialized | - | No |
 | `0034` | Dispatches interpreter-issued calls to native functions without an interpreter activation | Native calls otherwise enter the bytecode-call machinery before reaching the same class call entry, adding setup and argument spill work that is unnecessary for non-bytecode callees | - | No |
+| `0035` | Copies eligible dense array spreads directly into the argument accumulator | Unchanged builtin array iterators otherwise allocate an iterator and route every element through general property definition before the call | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -48,6 +48,7 @@ what we changed and why without opening a single `.patch` file.
 | `0035` | Copies eligible dense array spreads directly into the argument accumulator | Unchanged builtin array iterators otherwise allocate an iterator and route every element through general property definition before the call | - | No |
 | `0036` | Copies unchanged dense mapped arguments directly from their live variable-reference slots during apply | Avoids one exotic property lookup per forwarded argument while preserving the generic path for modified or sparse arguments objects | - | No |
 | `0037` | Skips COPY_ARGV materialization for functions proven not to write or retain argument slots | Callback callees that only read their arguments can reuse the caller's complete argument array without allocation or duplication | - | No |
+| `0038` | Avoids reifying frame-visible mapped arguments for length, indexed reads, and verified builtin apply calls | Non-escaping argument uses can read the active frame without allocating an arguments object, while all observable slow paths retain the ordinary object | - | Yes |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -44,6 +44,7 @@ what we changed and why without opening a single `.patch` file.
 | `0031` | Frames serialized function bodies and provides one checked bounded reader for eager and lazy-ready records | A declared body boundary and shared overflow-safe layout prevent malformed function records from consuming adjacent data while allowing later lazy materialization to use the same parser | - | **Yes** - changes bytecode record layout |
 | `0032` | Adds explicit caller-owned borrowed storage for lazy bytecode input | Embedders with stable immutable storage can avoid the engine-owned payload copy without changing the safe copied-lazy default | `JS_READ_OBJ_BORROW` | No |
 | `0033` | Defers atom interning for lazy bytecode entries until first use | Cold Metro function bodies need not construct their string and symbol atoms during startup; entries are validated, memoized, and shared when materialized | - | No |
+| `0034` | Dispatches interpreter-issued calls to native functions without an interpreter activation | Native calls otherwise enter the bytecode-call machinery before reaching the same class call entry, adding setup and argument spill work that is unnecessary for non-bytecode callees | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches
@@ -68,7 +69,7 @@ What this does
   Two to four short sentences.
 
 Why we need it
-  What in react-native-quickjs is broken or impossible without this.
+  What in the current engine is broken or impossible without this.
 
 What it adds
   JS_GetFrameInfoAtLevel()  - asks the engine where a given stack frame is

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -155,12 +155,16 @@
       "sha256": "d9a673b5baf7a531ed4cb42b51044291eec1ce66047573e3bbe41ec712f28e1c"
     },
     {
+      "name": "0039-pending-exception-wins-over-syntax-error.patch",
+      "sha256": "b1908cc455b58e11153669fabf8b852c879d55d6489b856633a3eab73a0cde3a"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "cff1fd7d06db53d1a3f54b23a4a198c75b0927eabc53412dcccb00b85415721c",
+    "quickjs.c": "add0b0a9d475d310cbdb93c35b586bbe3ffee29eb1cf3828f58e8f0429e46f9a",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -135,12 +135,16 @@
       "sha256": "bc5d8aba4747e808f9dcc0e0150db5cbbc34edbafa5624430ba8fb78fedc0242"
     },
     {
+      "name": "0034-native-call-dispatch.patch",
+      "sha256": "daab2bfee4648a13188b761e05a19b759e3fbe8604d72c11c777c903da8bdbf3"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "06463ac103bea52a86b1cc413ac056ec19980640ff6d57af5444a1728d4d5aad"
     }
   ],
   "files": {
-    "quickjs.c": "aab1e3ae19a8ee2b320814e3eb7054866f20b682680efeccf1edb3904025b950",
+    "quickjs.c": "da03d153cfaae4cc5da4dec87b294b84546a184b6c5b87a20dfced79b35455b3",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -147,12 +147,16 @@
       "sha256": "7e77d9dff7a41d41414973f83f03a1b94ba0b20e9818667a2a4ae38dc04d038f"
     },
     {
+      "name": "0037-argv-safe-argument-copy-elision.patch",
+      "sha256": "b6ec1f1a63685df26f5d2fcfa489cce16f2f067db7beaf8aa0d8562bd2f79d4e"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "06463ac103bea52a86b1cc413ac056ec19980640ff6d57af5444a1728d4d5aad"
     }
   ],
   "files": {
-    "quickjs.c": "70d9e662d84add35a77c8e9005d795a660cb9d3ab4d1cd4f3a085791c66354f1",
+    "quickjs.c": "3f5060efaf0bb792e486aa528ca691f5d444dab32d53e646a5c3a2f625b6313e",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -139,12 +139,16 @@
       "sha256": "daab2bfee4648a13188b761e05a19b759e3fbe8604d72c11c777c903da8bdbf3"
     },
     {
+      "name": "0035-dense-array-spread-fast-path.patch",
+      "sha256": "3ff93f85c0fa3d369be68e84c8413b8af52e3b5b47e4b6188847250a6f7339b2"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "06463ac103bea52a86b1cc413ac056ec19980640ff6d57af5444a1728d4d5aad"
     }
   ],
   "files": {
-    "quickjs.c": "da03d153cfaae4cc5da4dec87b294b84546a184b6c5b87a20dfced79b35455b3",
+    "quickjs.c": "58ca32534a78038fd8a2cfda633a14c9e16aa358602d8d349d386bffa27b0cb0",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -143,12 +143,16 @@
       "sha256": "3ff93f85c0fa3d369be68e84c8413b8af52e3b5b47e4b6188847250a6f7339b2"
     },
     {
+      "name": "0036-mapped-arguments-fast-copy.patch",
+      "sha256": "7e77d9dff7a41d41414973f83f03a1b94ba0b20e9818667a2a4ae38dc04d038f"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "06463ac103bea52a86b1cc413ac056ec19980640ff6d57af5444a1728d4d5aad"
     }
   ],
   "files": {
-    "quickjs.c": "58ca32534a78038fd8a2cfda633a14c9e16aa358602d8d349d386bffa27b0cb0",
+    "quickjs.c": "70d9e662d84add35a77c8e9005d795a660cb9d3ab4d1cd4f3a085791c66354f1",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -151,12 +151,16 @@
       "sha256": "b6ec1f1a63685df26f5d2fcfa489cce16f2f067db7beaf8aa0d8562bd2f79d4e"
     },
     {
+      "name": "0038-arguments-reification-elision.patch",
+      "sha256": "d9a673b5baf7a531ed4cb42b51044291eec1ce66047573e3bbe41ec712f28e1c"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
-      "sha256": "06463ac103bea52a86b1cc413ac056ec19980640ff6d57af5444a1728d4d5aad"
+      "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "3f5060efaf0bb792e486aa528ca691f5d444dab32d53e646a5c3a2f625b6313e",
+    "quickjs.c": "cff1fd7d06db53d1a3f54b23a4a198c75b0927eabc53412dcccb00b85415721c",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",
@@ -173,7 +177,7 @@
     "list.h": "cb6e24e8ee54bccdd66234fe54cd702d1160b9841db2b9b9adeb5003afe301d5",
     "quickjs-atom.h": "66654ae6533d15073ea527979c453709d7ed83162142c656095a10dcef737a60",
     "quickjs-c-atomics.h": "29883c742a5c512278fce54d19b1b9af949006e1d7dfc9ffa2e0946b184d8c5c",
-    "quickjs-opcode.h": "ede502651cd914c9cf44ecf1202c5ac33263286a31c06065e2b0ea985463fb82",
+    "quickjs-opcode.h": "b245471b2c135189f1f7f431357c955509bcf8ed082552d07c598486e01ba980",
     "quickjs.h": "a532b83c8c37cc79fedff1846ed2469478fc4f1ca1e6197cb402443c66a8996d",
     "LICENSE": "96f73f9d2a16c21a36b418f06073be26e7d6d5e7c1bc99756b21a4f2c74ef171"
   }

--- a/engine/quickjs-rel/quickjs-opcode.h
+++ b/engine/quickjs-rel/quickjs-opcode.h
@@ -314,6 +314,9 @@ def(     source_loc, 9, 0, 0, u32x2) /* emitted in phase 1, removed in phase 3 *
    rewrites it into OP_debug in phase 3. */
 def(     debug_stmt, 2, 0, 0, u8) /* emitted in phase 1, removed in phase 3 */
 
+def(      args_recv, 3, 0, 1, u16)
+def(        args_el, 1, 2, 1, none)
+
 DEF(    push_minus1, 1, 0, 1, none_int)
 DEF(         push_0, 1, 0, 1, none_int)
 DEF(         push_1, 1, 0, 1, none_int)
@@ -364,8 +367,8 @@ DEF(   get_var_ref1, 1, 0, 1, none_var_ref)
 DEF(   get_var_ref2, 1, 0, 1, none_var_ref)
 DEF(   get_var_ref3, 1, 0, 1, none_var_ref)
 DEF(   put_var_ref0, 1, 1, 0, none_var_ref)
-DEF(   put_var_ref1, 1, 1, 0, none_var_ref)
-DEF(   put_var_ref2, 1, 1, 0, none_var_ref)
+DEF(     get_arg_el, 3, 1, 1, loc)
+DEF(apply_arguments, 3, 3, 1, loc)
 DEF(   put_var_ref3, 1, 1, 0, none_var_ref)
 DEF(   set_var_ref0, 1, 1, 1, none_var_ref)
 DEF(   set_var_ref1, 1, 1, 1, none_var_ref)

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -19310,6 +19310,28 @@ static bool needs_backtrace(JSValue exc)
     return can_store_error_stack(exc) || can_add_backtrace(exc);
 }
 
+static inline int js_call_c_function_fast(
+    JSContext *ctx, JSValueConst func_obj, JSValueConst this_obj, int argc,
+    JSValueConst *argv, int flags, JSValue *pret)
+{
+    JSObject *p;
+    JSClassCall *call_func;
+
+    if (unlikely(JS_VALUE_GET_TAG(func_obj) != JS_TAG_OBJECT))
+        return 0;
+    p = JS_VALUE_GET_OBJ(func_obj);
+    if (p->class_id == JS_CLASS_BYTECODE_FUNCTION)
+        return 0;
+    call_func = ctx->rt->class_array[p->class_id].call;
+    if (unlikely(!call_func))
+        return 0;
+    if (unlikely(js_poll_interrupts(ctx)))
+        *pret = JS_EXCEPTION;
+    else
+        *pret = call_func(ctx, func_obj, this_obj, argc, argv, flags);
+    return 1;
+}
+
 /* argv[] is modified if (flags & JS_CALL_FLAG_COPY_ARGV) = 0. */
 static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                                JSValueConst this_obj, JSValueConst new_target,
@@ -19896,6 +19918,8 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
             has_call_argc:
                 call_argv = sp - call_argc;
                 sf->cur_pc = pc;
+                if (!js_call_c_function_fast(ctx, call_argv[-1], JS_UNDEFINED, call_argc,
+                                             vc(call_argv), 0, &ret_val))
                 ret_val = JS_CallInternal(ctx, call_argv[-1], JS_UNDEFINED,
                                           JS_UNDEFINED, call_argc,
                                           vc(call_argv), 0);
@@ -19933,6 +19957,8 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 pc += 2;
                 call_argv = sp - call_argc;
                 sf->cur_pc = pc;
+                if (!js_call_c_function_fast(ctx, call_argv[-1], call_argv[-2], call_argc,
+                                             vc(call_argv), 0, &ret_val))
                 ret_val = JS_CallInternal(ctx, call_argv[-1], call_argv[-2],
                                           JS_UNDEFINED, call_argc,
                                           vc(call_argv), 0);

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -18615,6 +18615,54 @@ static __exception int js_append_enumerate(JSContext *ctx, JSValue *sp)
                                        JS_ITERATOR_KIND_VALUE);
     JS_FreeValue(ctx, iterator);
 
+    /* Used to squelch a -Wcast-function-type warning. */
+    JSCFunctionType ft2 = { .iterator_next = js_array_iterator_next };
+    if (is_array_iterator) {
+        JSPropertyDescriptor desc;
+        JSValue *src_arr;
+        uint32_t src_count, src_len;
+        JSObject *dst;
+        int ret;
+
+        ret = JS_GetOwnProperty(ctx, &desc,
+                                ctx->class_proto[JS_CLASS_ARRAY_ITERATOR],
+                                JS_ATOM_next);
+        if (ret < 0)
+            return -1;
+        if (ret > 0 && !(desc.flags & JS_PROP_GETSET)) {
+            bool next_ok = JS_IsCFunction(ctx, desc.value, ft2.generic, 0);
+            if (next_ok && js_get_fast_array(ctx, sp[-1], &src_arr, &src_count)) {
+                if (!js_get_length32(ctx, &src_len, sp[-1]) &&
+                    js_get_fast_array(ctx, sp[-1], &src_arr, &src_count) &&
+                    src_len == src_count) {
+                    dst = JS_VALUE_GET_OBJ(sp[-3]);
+                    if (dst->class_id == JS_CLASS_ARRAY && dst->fast_array &&
+                        dst->u.array.count == pos &&
+                        JS_VALUE_GET_TAG(dst->prop[0].u.value) == JS_TAG_INT &&
+                        (get_shape_prop(dst->shape)->flags & JS_PROP_WRITABLE)) {
+                        uint32_t k, new_count = pos + src_count;
+                        if (new_count >= pos) {
+                            if (new_count > dst->u.array.u1.size &&
+                                expand_fast_array(ctx, dst, new_count)) {
+                                js_free_desc(ctx, &desc);
+                                return -1;
+                            }
+                            for (k = 0; k < src_count; k++)
+                                dst->u.array.u.values[pos + k] = js_dup(src_arr[k]);
+                            dst->u.array.count = new_count;
+                            dst->prop[0].u.value = js_int32(new_count);
+                            sp[-2] = js_int32(new_count);
+                            js_free_desc(ctx, &desc);
+                            return 0;
+                        }
+                    }
+                }
+            }
+        }
+        if (ret > 0)
+            js_free_desc(ctx, &desc);
+    }
+
     enumobj = JS_GetIterator(ctx, sp[-1], false);
     if (JS_IsException(enumobj))
         return -1;
@@ -18623,8 +18671,6 @@ static __exception int js_append_enumerate(JSContext *ctx, JSValue *sp)
         JS_FreeValue(ctx, enumobj);
         return -1;
     }
-    /* Used to squelch a -Wcast-function-type warning. */
-    JSCFunctionType ft2 = { .iterator_next = js_array_iterator_next };
     if (is_array_iterator
             &&  JS_IsCFunction(ctx, method, ft2.generic, 0)
             &&  js_get_fast_array(ctx, sp[-1], &arrp, &count32)) {

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -1525,6 +1525,7 @@ static __maybe_unused void JS_DumpShapes(JSRuntime *rt);
 
 static JSValue js_function_apply(JSContext *ctx, JSValueConst this_val,
                                  int argc, JSValueConst *argv, int magic);
+static int check_function(JSContext *ctx, JSValueConst obj);
 static void js_array_finalizer(JSRuntime *rt, JSValueConst val);
 static void js_array_mark(JSRuntime *rt, JSValueConst val,
                           JS_MarkFunc *mark_func);
@@ -3256,6 +3257,10 @@ int JS_GetStackDepth(JSContext *ctx)
     return depth;
 }
 
+static JSValue js_build_arguments(JSContext *ctx, int argc, JSValueConst *argv);
+static JSValue js_build_mapped_arguments(JSContext *ctx, int argc,
+                                         JSValueConst *argv, JSStackFrame *sf,
+                                         int arg_count);
 int JS_GetLocalVariablesAtLevel(JSContext *ctx, int level,
                                 JSDebugLocalVar **pvars, int *pcount)
 {
@@ -3291,6 +3296,23 @@ int JS_GetLocalVariablesAtLevel(JSContext *ctx, int level,
         return -1;
 
     int idx = 0;
+    for (int i = 0; i < b->var_count; i++) {
+        if (b->vardefs[b->arg_count + i].var_name == JS_ATOM_arguments &&
+            JS_VALUE_GET_TAG(sf->var_buf[i]) != JS_TAG_OBJECT) {
+            JSValue arguments;
+            if (b->is_strict_mode || !b->has_simple_parameter_list)
+                arguments = js_build_arguments(ctx, sf->arg_count, sf->arg_buf);
+            else
+                arguments = js_build_mapped_arguments(ctx, sf->arg_count,
+                                                      sf->arg_buf, sf,
+                                                      min_int(sf->arg_count,
+                                                              b->arg_count));
+            if (JS_IsException(arguments))
+                goto fail;
+            sf->var_buf[i] = arguments;
+            break;
+        }
+    }
 
 #define APPEND_VAR(vd_, value_, is_arg_)                                  \
     do {                                                                  \
@@ -18020,6 +18042,58 @@ static JSValue js_build_mapped_arguments(JSContext *ctx, int argc,
     return JS_EXCEPTION;
 }
 
+static JSObject *js_args_apply_is_builtin(JSValueConst v)
+{
+    JSObject *p;
+    if (JS_VALUE_GET_TAG(v) != JS_TAG_OBJECT)
+        return NULL;
+    p = JS_VALUE_GET_OBJ(v);
+    if (p->class_id == JS_CLASS_C_FUNCTION &&
+        p->u.cfunc.cproto == JS_CFUNC_generic_magic &&
+        p->u.cfunc.c_function.generic_magic == js_function_apply &&
+        p->u.cfunc.magic == 0)
+        return p;
+    return NULL;
+}
+
+static no_inline JSValue js_args_memo(JSContext *ctx, JSValue *slot,
+                                      int argc, JSValueConst *argv,
+                                      JSStackFrame *sf, int arg_count)
+{
+    JSValue v;
+    if (likely(JS_VALUE_GET_TAG(*slot) != JS_TAG_UNINITIALIZED))
+        return *slot;
+    v = js_build_mapped_arguments(ctx, argc, argv, sf, min_int(argc, arg_count));
+    if (unlikely(JS_IsException(v)))
+        return JS_EXCEPTION;
+    *slot = v;
+    return v;
+}
+
+static no_inline JSValue js_args_el_slow(JSContext *ctx, JSValue *slot,
+                                        JSValue key, int argc,
+                                        JSValueConst *argv, JSStackFrame *sf,
+                                        int arg_count)
+{
+    JSValue ao = js_args_memo(ctx, slot, argc, argv, sf, arg_count);
+    if (unlikely(JS_IsException(ao)))
+        return JS_EXCEPTION;
+    return JS_GetPropertyValue(ctx, ao, key);
+}
+
+static no_inline JSValue js_args_apply_reified(JSContext *ctx, JSValue *slot,
+                                               JSValue *st, int argc,
+                                               JSValueConst *argv, JSStackFrame *sf,
+                                               int arg_count)
+{
+    JSValue args2[2];
+    JSValue ao = js_args_memo(ctx, slot, argc, argv, sf, arg_count);
+    if (unlikely(JS_IsException(ao)))
+        return JS_EXCEPTION;
+    args2[0] = st[2];
+    args2[1] = ao;
+    return JS_Call(ctx, st[1], st[0], 2, vc(args2));
+}
 static JSValue build_for_in_iterator(JSContext *ctx, JSValue obj)
 {
     JSObject *p;
@@ -19341,6 +19415,7 @@ typedef enum {
     OP_SPECIAL_OBJECT_VAR_OBJECT,
     OP_SPECIAL_OBJECT_IMPORT_META,
     OP_SPECIAL_OBJECT_NULL_PROTO,
+    OP_SPECIAL_OBJECT_ARG_COUNT,
 } OPSpecialObjectEnum;
 
 #define FUNC_RET_AWAIT      0
@@ -19784,6 +19859,9 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     if (unlikely(JS_IsException(sp[-1])))
                         goto exception;
                     break;
+                case OP_SPECIAL_OBJECT_ARG_COUNT:
+                    *sp++ = js_int32(argc);
+                    break;
                 default:
                     abort();
                 }
@@ -20042,6 +20120,52 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 sf->cur_pc = pc;
 
                 ret_val = js_function_apply(ctx, sp[-3], 2, vc(&sp[-2]), magic);
+                if (unlikely(JS_IsException(ret_val)))
+                    goto exception;
+                JS_FreeValue(ctx, sp[-3]);
+                JS_FreeValue(ctx, sp[-2]);
+                JS_FreeValue(ctx, sp[-1]);
+                sp -= 3;
+                *sp++ = ret_val;
+            }
+            BREAK;
+
+        CASE(OP_get_arg_el):
+            {
+                int idx = get_u16(pc);
+                pc += 2;
+                if (likely(JS_VALUE_GET_TAG(sp[-1]) == JS_TAG_INT)) {
+                    uint32_t i = (uint32_t)JS_VALUE_GET_INT(sp[-1]);
+                    if (likely(i < (uint32_t)argc)) {
+                        sp[-1] = js_dup(i < (uint32_t)b->arg_count
+                                        ? arg_buf[i] : argv[i]);
+                        BREAK;
+                    }
+                }
+                sf->cur_pc = pc;
+                ret_val = js_args_el_slow(ctx, &var_buf[idx], sp[-1], argc, argv,
+                                          sf, b->arg_count);
+                if (unlikely(JS_IsException(ret_val)))
+                    goto exception;
+                sp[-1] = ret_val;
+            }
+            BREAK;
+
+        CASE(OP_apply_arguments):
+            {
+                int idx = get_u16(pc);
+                pc += 2;
+                sf->cur_pc = pc;
+                JSObject *pa = js_args_apply_is_builtin(sp[-2]);
+                if (likely(pa != NULL &&
+                           (arg_buf == (JSValue *)argv || argc <= b->arg_count))) {
+                    if (unlikely(check_function(pa->u.cfunc.realm, sp[-3])))
+                        goto exception;
+                    ret_val = JS_Call(ctx, sp[-3], sp[-1], argc, vc(arg_buf));
+                } else {
+                    ret_val = js_args_apply_reified(ctx, &var_buf[idx], sp - 3,
+                                                 argc, argv, sf, b->arg_count);
+                }
                 if (unlikely(JS_IsException(ret_val)))
                     goto exception;
                 JS_FreeValue(ctx, sp[-3]);
@@ -20554,8 +20678,6 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
         CASE(OP_get_var_ref2): *sp++ = js_dup(*var_refs[2]->pvalue); BREAK;
         CASE(OP_get_var_ref3): *sp++ = js_dup(*var_refs[3]->pvalue); BREAK;
         CASE(OP_put_var_ref0): set_value(ctx, var_refs[0]->pvalue, *--sp); BREAK;
-        CASE(OP_put_var_ref1): set_value(ctx, var_refs[1]->pvalue, *--sp); BREAK;
-        CASE(OP_put_var_ref2): set_value(ctx, var_refs[2]->pvalue, *--sp); BREAK;
         CASE(OP_put_var_ref3): set_value(ctx, var_refs[3]->pvalue, *--sp); BREAK;
         CASE(OP_set_var_ref0): set_value(ctx, var_refs[0]->pvalue, js_dup(sp[-1])); BREAK;
         CASE(OP_set_var_ref1): set_value(ctx, var_refs[1]->pvalue, js_dup(sp[-1])); BREAK;
@@ -38144,8 +38266,11 @@ static void put_short_code(DynBuf *bc_out, int op, int idx)
             dbuf_putc(bc_out, OP_get_var_ref0 + idx);
             return;
         case OP_put_var_ref:
-            dbuf_putc(bc_out, OP_put_var_ref0 + idx);
-            return;
+            if (idx == 0) {
+                dbuf_putc(bc_out, OP_put_var_ref0);
+                return;
+            }
+            break;
         case OP_set_var_ref:
             dbuf_putc(bc_out, OP_set_var_ref0 + idx);
             return;
@@ -38175,6 +38300,128 @@ static void put_short_code(DynBuf *bc_out, int op, int idx)
 }
 
 /* peephole optimizations and resolve goto/labels */
+
+enum {
+    JS_ARGS_KIND_NONE,
+    JS_ARGS_KIND_LENGTH,
+    JS_ARGS_KIND_ELEM,
+    JS_ARGS_KIND_APPLY,
+};
+
+static int js_args_find_elem_load(const uint8_t *bc_buf, int bc_len, int pos_next)
+{
+    int pos, op, len, depth = 1;
+    const JSOpCode *oi;
+
+    for (pos = pos_next; pos < bc_len; pos += len) {
+        op = bc_buf[pos];
+        oi = &opcode_info[op];
+        len = oi->size;
+        if (len <= 0 || pos + len > bc_len)
+            return -1;
+        if (op == OP_get_array_el && depth == 2)
+            return pos;
+        switch (oi->fmt) {
+        case OP_FMT_label:
+        case OP_FMT_label8:
+        case OP_FMT_label16:
+        case OP_FMT_label_u16:
+        case OP_FMT_atom_label_u8:
+        case OP_FMT_atom_label_u16:
+        case OP_FMT_npop:
+        case OP_FMT_npopx:
+        case OP_FMT_npop_u16:
+            return -1;
+        default:
+            break;
+        }
+        switch (op) {
+        case OP_label:
+        case OP_with_get_var:   case OP_with_delete_var:
+        case OP_with_make_ref:  case OP_with_get_ref:
+        case OP_with_get_ref_undef: case OP_with_put_var:
+        case OP_catch:          case OP_nip_catch:
+        case OP_for_of_start:   case OP_for_await_of_start:
+        case OP_iterator_close:
+        case OP_drop:           case OP_nip:  case OP_nip1:
+        case OP_return:         case OP_return_undef:
+        case OP_return_async:   case OP_throw: case OP_throw_error:
+        case OP_ret:            case OP_gosub:
+            return -1;
+        default:
+            break;
+        }
+        depth += (int)oi->n_push - (int)oi->n_pop;
+        if (depth < 1)
+            return -1;
+    }
+    return -1;
+}
+
+static int js_args_site_kind(CodeContext *cc, int pos_next, bool mapped, int *pel)
+{
+    int el;
+    if (code_match(cc, pos_next, OP_get_field, -1))
+        return cc->atom == JS_ATOM_length ? JS_ARGS_KIND_LENGTH
+                                          : JS_ARGS_KIND_NONE;
+    if (!mapped)
+        return JS_ARGS_KIND_NONE;
+    if (code_match(cc, pos_next, OP_call_method, 2, -1))
+        return JS_ARGS_KIND_APPLY;
+    el = js_args_find_elem_load(cc->bc_buf, cc->bc_len, pos_next);
+    if (el >= 0) {
+        *pel = el;
+        return JS_ARGS_KIND_ELEM;
+    }
+    return JS_ARGS_KIND_NONE;
+}
+
+static int js_args_elide_scan(JSFunctionDef *s, uint8_t *bc_buf, int bc_len,
+                              bool mapped, bool mark)
+{
+    CodeContext cc;
+    int pos, op, len, fmt, A, kinds = 0;
+
+    A = s->arguments_var_idx;
+    if (A < 0 || A >= s->var_count)
+        return -1;
+    if (s->arguments_arg_idx >= 0 || s->has_eval_call ||
+        s->var_object_idx >= 0 || s->arg_var_object_idx >= 0) {
+        return -1;
+    }
+    if (s->vars[A].is_captured) {
+        return -1;
+    }
+    cc.bc_buf = bc_buf;
+    cc.bc_len = bc_len;
+    for (pos = 0; pos < bc_len; pos += len) {
+        int kind, el = -1;
+        op = bc_buf[pos];
+        len = opcode_info[op].size;
+        if (len <= 0)
+            return -1;
+        fmt = opcode_info[op].fmt;
+        if (fmt == OP_FMT_none_loc || fmt == OP_FMT_loc8)
+            return -1;
+        if (fmt != OP_FMT_loc)
+            continue;
+        if (get_u16(bc_buf + pos + 1) != A)
+            continue;
+        if (op != OP_get_loc)
+            return -1;
+        kind = js_args_site_kind(&cc, pos + len, mapped, &el);
+        if (kind == JS_ARGS_KIND_NONE)
+            return -1;
+        kinds |= 1 << kind;
+        if (mark) {
+            bc_buf[pos] = OP_args_recv;
+            put_u16(bc_buf + pos + 1, kind);
+            if (kind == JS_ARGS_KIND_ELEM)
+                bc_buf[el] = OP_args_el;
+        }
+    }
+    return kinds;
+}
 static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
 {
     int pos, pos_next, bc_len, op, op1, len, i, line_num, col_num, patch_offsets;
@@ -38188,6 +38435,7 @@ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
     int objlit_k = 0;
     int objlit_live_count = 0;
     int objlit_template_index;
+    int args_elide_kinds = -1;
 
     label_slots = s->label_slots;
 
@@ -38211,6 +38459,26 @@ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
         s->line_number_last = s->line_num;
         s->col_number_last = s->col_num;
         s->line_number_last_pc = 0;
+    }
+
+    if (s->arguments_var_idx >= 0) {
+        bool mapped = !s->is_strict_mode && s->has_simple_parameter_list;
+        args_elide_kinds = js_args_elide_scan(s, (uint8_t *)bc_buf, bc_len,
+                                              mapped, false);
+        if (args_elide_kinds >= 0) {
+            js_args_elide_scan(s, (uint8_t *)bc_buf, bc_len, mapped, true);
+            if (mapped && (args_elide_kinds &
+                           ((1 << JS_ARGS_KIND_ELEM) |
+                            (1 << JS_ARGS_KIND_APPLY)))) {
+                for (i = 0; i < s->arg_count; i++)
+                    capture_var(s, &s->args[i]);
+            }
+            if (args_elide_kinds &
+                ((1 << JS_ARGS_KIND_ELEM) | (1 << JS_ARGS_KIND_APPLY))) {
+                dbuf_putc(&bc_out, OP_set_loc_uninitialized);
+                dbuf_put_u16(&bc_out, s->arguments_var_idx);
+            }
+        }
     }
 
     /* initialize the 'home_object' variable if needed */
@@ -38243,7 +38511,7 @@ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
         }
     }
     /* initialize the 'arguments' variable if needed */
-    if (s->arguments_var_idx >= 0) {
+    if (s->arguments_var_idx >= 0 && args_elide_kinds < 0) {
         if (s->is_strict_mode || !s->has_simple_parameter_list) {
             dbuf_putc(&bc_out, OP_special_object);
             dbuf_putc(&bc_out, OP_SPECIAL_OBJECT_ARGUMENTS);
@@ -38810,6 +39078,49 @@ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
                 break;
             }
             goto no_change;
+        case OP_args_recv:
+            {
+                int kind = get_u16(bc_buf + pos + 1);
+                assert(args_elide_kinds >= 0);
+                switch (kind) {
+                case JS_ARGS_KIND_LENGTH:
+                    /* Removing get_field(length) requires releasing its atom. */
+                    if (!code_match(&cc, pos_next, OP_get_field, -1) ||
+                        cc.atom != JS_ATOM_length)
+                        goto args_elide_desync;
+                    JS_FreeAtom(ctx, cc.atom);
+                    if (cc.line_num >= 0) line_num = cc.line_num;
+                    if (cc.col_num >= 0) col_num = cc.col_num;
+                    add_pc2line_info(s, bc_out.size, line_num, col_num);
+                    dbuf_putc(&bc_out, OP_special_object);
+                    dbuf_putc(&bc_out, OP_SPECIAL_OBJECT_ARG_COUNT);
+                    pos_next = cc.pos;
+                    break;
+                case JS_ARGS_KIND_APPLY:
+                    if (!code_match(&cc, pos_next, OP_call_method, 2, -1))
+                        goto args_elide_desync;
+                    if (cc.line_num >= 0) line_num = cc.line_num;
+                    if (cc.col_num >= 0) col_num = cc.col_num;
+                    add_pc2line_info(s, bc_out.size, line_num, col_num);
+                    dbuf_putc(&bc_out, OP_apply_arguments);
+                    dbuf_put_u16(&bc_out, s->arguments_var_idx);
+                    pos_next = cc.pos;
+                    break;
+                case JS_ARGS_KIND_ELEM:
+                    break;
+                default:
+                args_elide_desync:
+                    JS_ThrowInternalError(ctx, "arguments elision desync (kind=%d, pos=%d)",
+                                          kind, pos);
+                    goto fail;
+                }
+            }
+            break;
+        case OP_args_el:
+            add_pc2line_info(s, bc_out.size, line_num, col_num);
+            dbuf_putc(&bc_out, OP_get_arg_el);
+            dbuf_put_u16(&bc_out, s->arguments_var_idx);
+            break;
 
         case OP_get_loc:
             {

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -1010,7 +1010,7 @@ typedef struct JSFunctionBytecode {
        filled and cannot be re-parsed, so every later call has to fail rather
        than run with a NULL byte_code_buf. */
     uint8_t lazy_failed : 1;
-    /* XXX: 2 bits available */
+    uint8_t argv_safe : 1;
     uint8_t *byte_code_buf; /* (self pointer) */
     int byte_code_len;
     /* Runtime-only unified IC storage. It is allocated on first successful fill. */
@@ -19163,6 +19163,8 @@ static void close_lexical_var(JSContext *ctx, JSFunctionBytecode *b,
 }
 
 #define JS_CALL_FLAG_COPY_ARGV   (1 << 1)
+
+#define JS_ARGV_SAFE(b) ((b)->argv_safe)
 #define JS_CALL_FLAG_GENERATOR   (1 << 2)
 
 static JSValue js_call_c_function(JSContext *ctx, JSValueConst func_obj,
@@ -19470,7 +19472,8 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
             return JS_EXCEPTION;
     }
 
-    if (unlikely(argc < b->arg_count || (flags & JS_CALL_FLAG_COPY_ARGV))) {
+    if (unlikely(argc < b->arg_count ||
+                 ((flags & JS_CALL_FLAG_COPY_ARGV) && !JS_ARGV_SAFE(b)))) {
         arg_allocated_size = b->arg_count;
     } else {
         arg_allocated_size = 0;
@@ -39450,6 +39453,8 @@ static int add_module_variables(JSContext *ctx, JSFunctionDef *fd)
 /* create a function object from a function definition. The function
    definition is freed. All the child functions are also created. It
    must be done this way to resolve all the variables. */
+static void js_scan_argv_safe(JSFunctionBytecode *b);
+
 static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
 {
     JSValue func_obj;
@@ -39604,6 +39609,7 @@ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
     b->byte_code_buf = (void *)((uint8_t*)b + byte_code_offset);
     b->byte_code_len = fd->byte_code.size;
     memcpy(b->byte_code_buf, fd->byte_code.buf, fd->byte_code.size);
+    js_scan_argv_safe(b);
     js_free(ctx, fd->byte_code.buf);
     fd->byte_code.buf = NULL;
 
@@ -42596,6 +42602,49 @@ static int bc_get_buf(BCReaderState *s, void *buf, uint32_t buf_len)
 }
 
 static JSString *JS_ReadString(BCReaderState *s);
+static bool js_argv_safe_opcode(const uint8_t *bc, int pos, int op)
+{
+    switch (op) {
+    case OP_put_arg:  case OP_set_arg:
+    case OP_put_arg0: case OP_set_arg0:
+    case OP_put_arg1: case OP_set_arg1:
+    case OP_put_arg2: case OP_set_arg2:
+    case OP_put_arg3: case OP_set_arg3:
+    case OP_make_arg_ref:
+    case OP_eval:     case OP_apply_eval:
+    case OP_get_arg_el:
+    case OP_apply_arguments:
+        return false;
+    case OP_special_object:
+        return bc[pos + 1] != OP_SPECIAL_OBJECT_MAPPED_ARGUMENTS;
+    default:
+        return true;
+    }
+}
+
+static void js_scan_argv_safe(JSFunctionBytecode *b)
+{
+    const uint8_t *bc;
+    int pos = 0, len;
+
+    if (b == NULL)
+        return;
+    bc = b->byte_code_buf;
+    len = b->byte_code_len;
+    if (bc == NULL || len <= 0)
+        return;
+
+    while (pos < len) {
+        int op = bc[pos];
+        int sz = short_opcode_info(op).size;
+        if (sz <= 0 || pos + sz > len)
+            return;
+        if (!js_argv_safe_opcode(bc, pos, op))
+            return;
+        pos += sz;
+    }
+    b->argv_safe = 1;
+}
 
 /* Interns atom `idx` from its recorded position in the payload and memoises it
    in idx_to_atom. Reads through a scratch cursor so the caller's parse position
@@ -42741,6 +42790,7 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
 {
     uint8_t *bc_buf;
     int pos, len, op;
+    bool argv_safe = true;
     JSAtom atom;
     uint32_t idx;
 
@@ -42763,6 +42813,8 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
             b->byte_code_len = pos;
             return -1;
         }
+        if (!js_argv_safe_opcode(bc_buf, pos, op))
+            argv_safe = false;
         switch(short_opcode_info(op).fmt) {
         case OP_FMT_atom:
         case OP_FMT_atom_u8:
@@ -42794,6 +42846,7 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
 #endif
         pos += len;
     }
+    b->argv_safe = argv_safe;
     return 0;
 }
 

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -40570,6 +40570,11 @@ static __exception int js_parse_function_decl2(JSParseState *s,
                     }
                 }
             } else {
+                /* A pending exception (stack overflow, interrupt, OOM) set while
+                   reading this token is the real error; reporting a syntax error
+                   here would replace it and hide what actually happened. */
+                if (JS_HasException(s->ctx))
+                    goto fail;
                 js_parse_error(s, "missing formal parameter");
                 goto fail;
             }

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -46134,6 +46134,12 @@ static JSValue *build_arg_list(JSContext *ctx, uint32_t *plen,
         for(i = 0; i < len; i++) {
             tab[i] = js_dup(p->u.array.u.values[i]);
         }
+    } else if (p->class_id == JS_CLASS_MAPPED_ARGUMENTS &&
+               p->fast_array &&
+               len == p->u.array.count) {
+        for(i = 0; i < len; i++) {
+            tab[i] = js_dup(*p->u.array.u.var_refs[i]->pvalue);
+        }
     } else {
         for(i = 0; i < len; i++) {
             ret = JS_GetPropertyUint32(ctx, array_arg, i);

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -32,6 +32,7 @@ react {
     if (usingHermes) {
         hermesCommand = hermescPath().absolutePath
     }
+    hermesEnabled = usingHermes
     entryFile = file(exampleMode == "benchmark" ? "../../index.benchmark.js" : "../../index.js")
 
     /* Folders */
@@ -134,6 +135,7 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
+    implementation(project(":jsibench"))
 
     if (usingHermes) {
         implementation("com.facebook.react:hermes-android")

--- a/example/android/app/src/main/java/com/reactnativequickjs/example/JsiBenchModule.kt
+++ b/example/android/app/src/main/java/com/reactnativequickjs/example/JsiBenchModule.kt
@@ -1,0 +1,35 @@
+package com.reactnativequickjs.example
+
+import com.facebook.react.bridge.JavaScriptContextHolder
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.soloader.SoLoader
+
+@DoNotStrip
+@ReactModule(name = JsiBenchModule.NAME)
+class JsiBenchModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
+  override fun getName(): String = NAME
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  fun install(): Boolean {
+    val context: JavaScriptContextHolder =
+        reactApplicationContext.javaScriptContextHolder ?: return false
+    val pointer = context.get()
+    if (pointer == 0L) return false
+    nativeInstall(pointer)
+    return true
+  }
+
+  private external fun nativeInstall(jsi: Long)
+
+  companion object {
+    const val NAME = "RNQJSJsiBench"
+
+    init {
+      SoLoader.loadLibrary("rnqjsbench")
+    }
+  }
+}

--- a/example/android/app/src/main/java/com/reactnativequickjs/example/TtiPackage.kt
+++ b/example/android/app/src/main/java/com/reactnativequickjs/example/TtiPackage.kt
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.ViewManager
 
 class TtiPackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
-      listOf(TtiModule(reactContext))
+      listOf(TtiModule(reactContext), JsiBenchModule(reactContext))
 
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
       emptyList()

--- a/example/android/jsibench/build.gradle
+++ b/example/android/jsibench/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: "com.android.library"
+
+android {
+    namespace "com.reactnativequickjs.jsibench"
+    compileSdk rootProject.ext.compileSdkVersion
+    ndkVersion rootProject.ext.ndkVersion
+
+    defaultConfig {
+        minSdk rootProject.ext.minSdkVersion
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_STL=c++_shared"
+            }
+        }
+    }
+
+    buildFeatures {
+        prefab true
+    }
+
+    externalNativeBuild {
+        cmake {
+            path file("src/main/cpp/CMakeLists.txt")
+            version "3.22.1"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.facebook.react:react-android")
+}

--- a/example/android/jsibench/src/main/cpp/CMakeLists.txt
+++ b/example/android/jsibench/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(rnqjsbench CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ReactAndroid REQUIRED CONFIG)
+find_package(fbjni REQUIRED CONFIG)
+
+add_library(rnqjsbench SHARED JsiBenchBindings.cpp)
+target_link_libraries(rnqjsbench PRIVATE
+  ReactAndroid::jsi
+  ReactAndroid::reactnative
+  fbjni::fbjni
+  log
+)

--- a/example/android/jsibench/src/main/cpp/JsiBenchBindings.cpp
+++ b/example/android/jsibench/src/main/cpp/JsiBenchBindings.cpp
@@ -1,0 +1,44 @@
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+namespace {
+
+class JsiBenchModule : public jni::JavaClass<JsiBenchModule> {
+ public:
+  static constexpr const char *kJavaDescriptor =
+      "Lcom/reactnativequickjs/example/JsiBenchModule;";
+
+  static void registerNatives() {
+    javaClassLocal()->registerNatives({
+        makeNativeMethod("nativeInstall", nativeInstall),
+    });
+  }
+
+ private:
+  static void nativeInstall(
+      jni::alias_ref<JsiBenchModule> /*module*/, jlong runtime_ptr) {
+    auto &runtime = *reinterpret_cast<jsi::Runtime *>(runtime_ptr);
+    auto bench = jsi::Object(runtime);
+    auto noop = [](jsi::Runtime &, const jsi::Value &, const jsi::Value *,
+                   size_t) { return jsi::Value(1); };
+    auto add = [&](const char *name, unsigned int arity) {
+      auto function = jsi::Function::createFromHostFunction(
+          runtime, jsi::PropNameID::forAscii(runtime, name), arity, noop);
+      bench.setProperty(runtime, name, std::move(function));
+    };
+    add("native0", 0);
+    add("native1", 1);
+    add("native4", 4);
+    add("native8", 8);
+    runtime.global().setProperty(runtime, "__RNQJSJsiBench", std::move(bench));
+  }
+};
+
+}  // namespace
+}  // namespace facebook::react
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+  return facebook::jni::initialize(
+      vm, [] { facebook::react::JsiBenchModule::registerNatives(); });
+}

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -3,4 +3,5 @@ plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'com.reactnativequickjs.example'
 include ':app'
+include ':jsibench'
 includeBuild('../../node_modules/@react-native/gradle-plugin')

--- a/example/src/benchmark/data.ts
+++ b/example/src/benchmark/data.ts
@@ -41,5 +41,5 @@ export const notifications = [
 export const navItems = [
   ['feed', 'Feed'], ['search', 'Search'], ['saved', 'Saved'], ['notifications', 'Notifications'],
   ['profile', 'Profile'], ['settings', 'Settings'], ['analytics', 'Analytics'], ['help', 'Help'],
-  ['orders', 'Orders'], ['messages', 'Messages'],
+  ['orders', 'Orders'], ['messages', 'Messages'], ['jsiBenchmark', 'JSI throughput'],
 ] as const;

--- a/example/src/benchmark/router.ts
+++ b/example/src/benchmark/router.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type Route = 'dashboard' | 'feed' | 'search' | 'article' | 'profile' | 'settings' | 'editProfile' | 'notifications' | 'saved' | 'analytics' | 'help' | 'orders' | 'orderDetails' | 'messages' | 'messageDetails' | 'security' | 'preferences';
+export type Route = 'dashboard' | 'feed' | 'search' | 'article' | 'profile' | 'settings' | 'editProfile' | 'notifications' | 'saved' | 'analytics' | 'help' | 'orders' | 'orderDetails' | 'messages' | 'messageDetails' | 'security' | 'preferences' | 'jsiBenchmark';
 type Screen = React.ComponentType<any>;
 
 // These static factories keep every screen discoverable to Metro while avoiding
@@ -23,4 +23,5 @@ export const screenFactories: Record<Route, () => Screen> = {
   messageDetails: () => require('./screens/MessageDetailsScreen').default,
   security: () => require('./screens/SecurityScreen').default,
   preferences: () => require('./screens/PreferencesScreen').default,
+  jsiBenchmark: () => require('./screens/JsiBenchmarkScreen').default,
 };

--- a/example/src/benchmark/screens/JsiBenchmarkScreen.tsx
+++ b/example/src/benchmark/screens/JsiBenchmarkScreen.tsx
@@ -32,9 +32,9 @@ function runCalls(fn: BenchFunction, args: number[]) {
 
 function measure(name: string, fn: BenchFunction, args: number[]) {
   runCalls(fn, args);
-  const start = global.performance.now();
+  const start = globalThis.performance.now();
   runCalls(fn, args);
-  const elapsed = global.performance.now() - start;
+  const elapsed = globalThis.performance.now() - start;
   return { name, ns: (elapsed * 1_000_000) / iterations };
 }
 
@@ -57,17 +57,11 @@ export default function JsiBenchmarkScreen({ back }: { back: () => void }) {
       setOutput('JSI benchmark bindings are unavailable.');
       return;
     }
-    const nativeC0 = (globalThis as typeof globalThis & { __RNQJSNativeC0?: BenchFunction }).__RNQJSNativeC0;
-    if (typeof nativeC0 !== 'function') {
-      setOutput('QuickJS native C function is unavailable.');
-      return;
-    }
     const jsCall = (arity: number) => {
       const fn = (...values: number[]) => values.length + 1;
       return measure(`JS→JS ${arity}`, fn, Array.from({ length: arity }, (_, i) => i));
     };
       const rows = [
-      measure('QuickJS C function 0', nativeC0, []),
       measure('HostFunction 0', bench.native0, []),
       measure('HostFunction 1', bench.native1, [1]),
       measure('HostFunction 4', bench.native4, [1, 2, 3, 4]),

--- a/example/src/benchmark/screens/JsiBenchmarkScreen.tsx
+++ b/example/src/benchmark/screens/JsiBenchmarkScreen.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { Pressable, ScrollView, Text } from 'react-native';
+import { ScreenFrame, styles } from '../components';
+
+type BenchFunction = (...args: number[]) => number;
+type BenchBindings = {
+  native0: BenchFunction;
+  native1: BenchFunction;
+  native4: BenchFunction;
+  native8: BenchFunction;
+};
+
+const iterations = 10_000_000;
+
+function runCalls(fn: BenchFunction, args: number[]) {
+  switch (args.length) {
+    case 0:
+      for (let i = 0; i < iterations; i++) fn();
+      return;
+    case 1:
+      for (let i = 0; i < iterations; i++) fn(args[0]);
+      return;
+    case 4:
+      for (let i = 0; i < iterations; i++) fn(args[0], args[1], args[2], args[3]);
+      return;
+    case 8:
+      for (let i = 0; i < iterations; i++) fn(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+      return;
+    default: throw new Error(`unsupported arity ${args.length}`);
+  }
+}
+
+function measure(name: string, fn: BenchFunction, args: number[]) {
+  runCalls(fn, args);
+  const start = global.performance.now();
+  runCalls(fn, args);
+  const elapsed = global.performance.now() - start;
+  return { name, ns: (elapsed * 1_000_000) / iterations };
+}
+
+export default function JsiBenchmarkScreen({ back }: { back: () => void }) {
+  const [output, setOutput] = useState('Tap Run to measure JSI calls.');
+  const run = () => {
+    const module = require('react-native').NativeModules.RNQJSJsiBench as
+      | { install: () => boolean }
+      | undefined;
+    if (!module) {
+      setOutput('JSI benchmark module is unavailable.');
+      return;
+    }
+    if (!module.install()) {
+      setOutput('JSI benchmark bindings could not be installed.');
+      return;
+    }
+    const bench = (globalThis as typeof globalThis & { __RNQJSJsiBench?: BenchBindings }).__RNQJSJsiBench;
+    if (!bench) {
+      setOutput('JSI benchmark bindings are unavailable.');
+      return;
+    }
+    const nativeC0 = (globalThis as typeof globalThis & { __RNQJSNativeC0?: BenchFunction }).__RNQJSNativeC0;
+    if (typeof nativeC0 !== 'function') {
+      setOutput('QuickJS native C function is unavailable.');
+      return;
+    }
+    const jsCall = (arity: number) => {
+      const fn = (...values: number[]) => values.length + 1;
+      return measure(`JS→JS ${arity}`, fn, Array.from({ length: arity }, (_, i) => i));
+    };
+      const rows = [
+      measure('QuickJS C function 0', nativeC0, []),
+      measure('HostFunction 0', bench.native0, []),
+      measure('HostFunction 1', bench.native1, [1]),
+      measure('HostFunction 4', bench.native4, [1, 2, 3, 4]),
+      measure('HostFunction 8', bench.native8, [1, 2, 3, 4, 5, 6, 7, 8]),
+      jsCall(4),
+    ];
+    const text = rows.map(row => `${row.name}: ${row.ns.toFixed(1)} ns/call`).join('\n');
+    console.log(`RNQJS_JSI_BENCH engine=${(globalThis as any).HermesInternal ? 'hermes' : 'quickjs'}\n${text}`);
+    setOutput(text);
+  };
+
+  return <ScreenFrame title="JSI throughput" onBack={back}>
+    <ScrollView>
+      <Text style={styles.body}>The same JavaScript loop calls native HostFunctions under the selected engine. This runs only when requested, after startup.</Text>
+      <Pressable accessibilityLabel="run-jsi-benchmark" onPress={run} style={styles.button}>
+        <Text style={styles.buttonText}>Run benchmark</Text>
+      </Pressable>
+      <Text selectable style={[styles.body, { marginTop: 18 }]}>{output}</Text>
+    </ScrollView>
+  </ScreenFrame>;
+}

--- a/example/src/benchmark/utils.ts
+++ b/example/src/benchmark/utils.ts
@@ -2,7 +2,7 @@ import { FeedItem, accounts } from './data';
 
 export const formatMinutes = (minutes: number) => `${minutes} min read`;
 export const formatScore = (score: number) => `${score}% match`;
-export const formatCount = (count: number) => count.toLocaleString('en-US');
+export const formatCount = (count: number) => String(count);
 
 export function selectRecommended(items: FeedItem[]) {
   return items.filter(item => item.score >= 80).sort((a, b) => b.score - a.score);

--- a/src/runtime/QuickJSRuntime.cpp
+++ b/src/runtime/QuickJSRuntime.cpp
@@ -255,8 +255,8 @@ struct HostFunctionHandlers {
         heapArgs.resize(static_cast<size_t>(argc));
         args = heapArgs.data();
       }
-      for (int i = 0; i < argc; ++i) {
-        args[i] = runtime->borrowValue(argv[i]);
+      if (argc != 0) {
+        runtime->borrowValues(argv, static_cast<size_t>(argc), args);
       }
       jsi::Value thisValue = runtime->borrowValue(thisVal);
       jsi::Value result =
@@ -758,6 +758,47 @@ jsi::Value QuickJSRuntime::borrowValue(JSValue value) {
     return jsi::Value(make<jsi::BigInt>(allocPointerValue(value, false)));
   }
   return jsi::Value(make<jsi::Object>(allocPointerValue(value, false)));
+}
+
+void QuickJSRuntime::borrowValues(
+    JSValueConst *values, size_t count, jsi::Value *destination) {
+  for (size_t i = 0; i < count; ++i) {
+    JSValueConst value = values[i];
+    switch (JS_VALUE_GET_TAG(value)) {
+      case JS_TAG_UNDEFINED:
+        destination[i] = jsi::Value::undefined();
+        break;
+      case JS_TAG_NULL:
+        destination[i] = jsi::Value::null();
+        break;
+      case JS_TAG_BOOL:
+        destination[i] = jsi::Value(JS_VALUE_GET_BOOL(value) != 0);
+        break;
+      case JS_TAG_INT:
+        destination[i] = jsi::Value(JS_VALUE_GET_INT(value));
+        break;
+      case JS_TAG_FLOAT64:
+        destination[i] = jsi::Value(JS_VALUE_GET_FLOAT64(value));
+        break;
+      case JS_TAG_STRING:
+        destination[i] =
+            jsi::Value(make<jsi::String>(allocPointerValue(value, false)));
+        break;
+      case JS_TAG_SYMBOL:
+        destination[i] =
+            jsi::Value(make<jsi::Symbol>(allocPointerValue(value, false)));
+        break;
+      case JS_TAG_BIG_INT:
+      case JS_TAG_SHORT_BIG_INT:
+        destination[i] =
+            jsi::Value(make<jsi::BigInt>(allocPointerValue(value, false)));
+        break;
+      default:
+        destination[i] =
+            jsi::Value(make<jsi::Object>(allocPointerValue(value, false)));
+        break;
+    }
+  }
 }
 
 JSValue QuickJSRuntime::takeJSValue(jsi::Value &&value) {

--- a/src/runtime/QuickJSRuntime.cpp
+++ b/src/runtime/QuickJSRuntime.cpp
@@ -764,31 +764,6 @@ jsi::Value QuickJSRuntime::createValue(JSValue value) {
   return jsi::Value(createObjectFrom(value));
 }
 
-jsi::Value QuickJSRuntime::borrowValue(JSValue value) {
-  // Primitives carry no reference, so they are already borrow-shaped.
-  switch (JS_VALUE_GET_TAG(value)) {
-    case JS_TAG_UNDEFINED:
-      return jsi::Value::undefined();
-    case JS_TAG_NULL:
-      return jsi::Value::null();
-    case JS_TAG_BOOL:
-      return jsi::Value(JS_VALUE_GET_BOOL(value) != 0);
-    case JS_TAG_INT:
-      return jsi::Value(JS_VALUE_GET_INT(value));
-    case JS_TAG_FLOAT64:
-      return jsi::Value(JS_VALUE_GET_FLOAT64(value));
-    case JS_TAG_STRING:
-      return jsi::Value(make<jsi::String>(allocPointerValue(value, false)));
-    case JS_TAG_SYMBOL:
-      return jsi::Value(make<jsi::Symbol>(allocPointerValue(value, false)));
-    case JS_TAG_BIG_INT:
-    case JS_TAG_SHORT_BIG_INT:
-      return jsi::Value(make<jsi::BigInt>(allocPointerValue(value, false)));
-    default:
-      return jsi::Value(make<jsi::Object>(allocPointerValue(value, false)));
-  }
-}
-
 void QuickJSRuntime::borrowValues(
     JSValueConst *values, size_t count, jsi::Value *destination) {
   for (size_t i = 0; i < count; ++i) {

--- a/src/runtime/QuickJSRuntime.cpp
+++ b/src/runtime/QuickJSRuntime.cpp
@@ -233,6 +233,37 @@ JSClassExoticMethods gHostObjectExotic = {
     /* set_property */ HostObjectHandlers::setProperty,
 };
 
+/// Raw storage for the borrowed arguments of a host call. Only the entries
+/// actually built are destroyed, so an unused slot never holds an object.
+class InlineArgs {
+ public:
+  static constexpr size_t kCapacity = 8;
+
+  ~InlineArgs() {
+    reset();
+  }
+
+  jsi::Value *data() noexcept {
+    return reinterpret_cast<jsi::Value *>(storage_);
+  }
+
+  /// Constructs the next entry; a throw leaves it uncounted.
+  void emplace(QuickJSRuntime &runtime, JSValueConst value) {
+    new (data() + size_) jsi::Value(runtime.borrowValue(value));
+    ++size_;
+  }
+
+ private:
+  void reset() noexcept {
+    while (size_ != 0) {
+      data()[--size_].~Value();
+    }
+  }
+
+  alignas(jsi::Value) unsigned char storage_[kCapacity * sizeof(jsi::Value)];
+  size_t size_{0};
+};
+
 struct HostFunctionHandlers {
   static JSValue call(
       JSContext *ctx, JSValueConst funcObj, JSValueConst thisVal, int argc,
@@ -247,16 +278,18 @@ struct HostFunctionHandlers {
     try {
       // Borrowed, not dup'd: quickjs keeps argv and thisVal alive for the whole
       // call, so a reference taken here and dropped on return would cancel out.
-      constexpr int kInlineArgs = 8;
-      jsi::Value inlineArgs[kInlineArgs];
       std::vector<jsi::Value> heapArgs;
-      jsi::Value *args = inlineArgs;
-      if (argc > kInlineArgs) {
+      InlineArgs inlineArgs;
+      jsi::Value *args = nullptr;
+      if (argc > static_cast<int>(InlineArgs::kCapacity)) {
         heapArgs.resize(static_cast<size_t>(argc));
+        runtime->borrowValues(argv, static_cast<size_t>(argc), heapArgs.data());
         args = heapArgs.data();
-      }
-      if (argc != 0) {
-        runtime->borrowValues(argv, static_cast<size_t>(argc), args);
+      } else if (argc != 0) {
+        for (int i = 0; i < argc; ++i) {
+          inlineArgs.emplace(*runtime, argv[i]);
+        }
+        args = inlineArgs.data();
       }
       jsi::Value thisValue = runtime->borrowValue(thisVal);
       jsi::Value result =
@@ -319,7 +352,6 @@ JSValue microtaskJob(JSContext *ctx, int argc, JSValueConst *argv) {
 const char *kSymbolToStringSource = "(function (s) { return s.toString(); })";
 const char *kBigIntToStringSource =
     "(function (b, radix) { return b.toString(radix); })";
-
 }  // namespace
 
 QuickJSRuntime::QuickJSRuntime(QuickJSRuntimeConfig config)
@@ -734,70 +766,35 @@ jsi::Value QuickJSRuntime::createValue(JSValue value) {
 
 jsi::Value QuickJSRuntime::borrowValue(JSValue value) {
   // Primitives carry no reference, so they are already borrow-shaped.
-  if (JS_IsUndefined(value)) {
-    return jsi::Value::undefined();
+  switch (JS_VALUE_GET_TAG(value)) {
+    case JS_TAG_UNDEFINED:
+      return jsi::Value::undefined();
+    case JS_TAG_NULL:
+      return jsi::Value::null();
+    case JS_TAG_BOOL:
+      return jsi::Value(JS_VALUE_GET_BOOL(value) != 0);
+    case JS_TAG_INT:
+      return jsi::Value(JS_VALUE_GET_INT(value));
+    case JS_TAG_FLOAT64:
+      return jsi::Value(JS_VALUE_GET_FLOAT64(value));
+    case JS_TAG_STRING:
+      return jsi::Value(make<jsi::String>(allocPointerValue(value, false)));
+    case JS_TAG_SYMBOL:
+      return jsi::Value(make<jsi::Symbol>(allocPointerValue(value, false)));
+    case JS_TAG_BIG_INT:
+    case JS_TAG_SHORT_BIG_INT:
+      return jsi::Value(make<jsi::BigInt>(allocPointerValue(value, false)));
+    default:
+      return jsi::Value(make<jsi::Object>(allocPointerValue(value, false)));
   }
-  if (JS_IsNull(value)) {
-    return jsi::Value::null();
-  }
-  if (JS_IsBool(value)) {
-    return jsi::Value(static_cast<bool>(JS_ToBool(context_, value)));
-  }
-  if (JS_IsNumber(value)) {
-    double number = 0;
-    JS_ToFloat64(context_, &number, value);
-    return jsi::Value(number);
-  }
-  if (JS_IsString(value)) {
-    return jsi::Value(make<jsi::String>(allocPointerValue(value, false)));
-  }
-  if (JS_IsSymbol(value)) {
-    return jsi::Value(make<jsi::Symbol>(allocPointerValue(value, false)));
-  }
-  if (JS_IsBigInt(value)) {
-    return jsi::Value(make<jsi::BigInt>(allocPointerValue(value, false)));
-  }
-  return jsi::Value(make<jsi::Object>(allocPointerValue(value, false)));
 }
 
 void QuickJSRuntime::borrowValues(
     JSValueConst *values, size_t count, jsi::Value *destination) {
   for (size_t i = 0; i < count; ++i) {
-    JSValueConst value = values[i];
-    switch (JS_VALUE_GET_TAG(value)) {
-      case JS_TAG_UNDEFINED:
-        destination[i] = jsi::Value::undefined();
-        break;
-      case JS_TAG_NULL:
-        destination[i] = jsi::Value::null();
-        break;
-      case JS_TAG_BOOL:
-        destination[i] = jsi::Value(JS_VALUE_GET_BOOL(value) != 0);
-        break;
-      case JS_TAG_INT:
-        destination[i] = jsi::Value(JS_VALUE_GET_INT(value));
-        break;
-      case JS_TAG_FLOAT64:
-        destination[i] = jsi::Value(JS_VALUE_GET_FLOAT64(value));
-        break;
-      case JS_TAG_STRING:
-        destination[i] =
-            jsi::Value(make<jsi::String>(allocPointerValue(value, false)));
-        break;
-      case JS_TAG_SYMBOL:
-        destination[i] =
-            jsi::Value(make<jsi::Symbol>(allocPointerValue(value, false)));
-        break;
-      case JS_TAG_BIG_INT:
-      case JS_TAG_SHORT_BIG_INT:
-        destination[i] =
-            jsi::Value(make<jsi::BigInt>(allocPointerValue(value, false)));
-        break;
-      default:
-        destination[i] =
-            jsi::Value(make<jsi::Object>(allocPointerValue(value, false)));
-        break;
-    }
+    // Assignment, not placement construction: a conversion that throws must
+    // leave a live value behind for the vector's destructor to run.
+    destination[i] = borrowValue(values[i]);
   }
 }
 

--- a/src/runtime/QuickJSRuntime.h
+++ b/src/runtime/QuickJSRuntime.h
@@ -339,7 +339,7 @@ class QuickJSRuntime : public jsi::Runtime {
    * argument copies it, and every copy path takes a real reference, so a
    * borrowed wrapper cannot outlive the call that made it.
    */
-  jsi::Value borrowValue(JSValue value);
+  __attribute__((always_inline)) jsi::Value borrowValue(JSValue value);
 
   void borrowValues(
       JSValueConst *values, size_t count, jsi::Value *destination);

--- a/src/runtime/QuickJSRuntime.h
+++ b/src/runtime/QuickJSRuntime.h
@@ -341,6 +341,9 @@ class QuickJSRuntime : public jsi::Runtime {
    */
   jsi::Value borrowValue(JSValue value);
 
+  void borrowValues(
+      JSValueConst *values, size_t count, jsi::Value *destination);
+
   /// Takes the reference out of a jsi::Value that is about to be destroyed,
   /// rather than dup'ing a value whose destructor is about to free the
   /// original. Symmetric with borrowValue.

--- a/src/runtime/QuickJSRuntime.h
+++ b/src/runtime/QuickJSRuntime.h
@@ -339,7 +339,30 @@ class QuickJSRuntime : public jsi::Runtime {
    * argument copies it, and every copy path takes a real reference, so a
    * borrowed wrapper cannot outlive the call that made it.
    */
-  __attribute__((always_inline)) jsi::Value borrowValue(JSValue value);
+  __attribute__((always_inline)) jsi::Value borrowValue(JSValue value) {
+    // Primitives carry no reference, so they are already borrow-shaped.
+    switch (JS_VALUE_GET_TAG(value)) {
+      case JS_TAG_UNDEFINED:
+        return jsi::Value::undefined();
+      case JS_TAG_NULL:
+        return jsi::Value::null();
+      case JS_TAG_BOOL:
+        return jsi::Value(JS_VALUE_GET_BOOL(value) != 0);
+      case JS_TAG_INT:
+        return jsi::Value(JS_VALUE_GET_INT(value));
+      case JS_TAG_FLOAT64:
+        return jsi::Value(JS_VALUE_GET_FLOAT64(value));
+      case JS_TAG_STRING:
+        return jsi::Value(make<jsi::String>(allocPointerValue(value, false)));
+      case JS_TAG_SYMBOL:
+        return jsi::Value(make<jsi::Symbol>(allocPointerValue(value, false)));
+      case JS_TAG_BIG_INT:
+      case JS_TAG_SHORT_BIG_INT:
+        return jsi::Value(make<jsi::BigInt>(allocPointerValue(value, false)));
+      default:
+        return jsi::Value(make<jsi::Object>(allocPointerValue(value, false)));
+    }
+  }
 
   void borrowValues(
       JSValueConst *values, size_t count, jsi::Value *destination);

--- a/tests/debugger_test.cpp
+++ b/tests/debugger_test.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include <quickjs.h>
 }
 
+#include <algorithm>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -585,6 +586,23 @@ TEST_F(DebuggerTest, FrameInfoAtEveryLevel) {
   for (const auto &f : cap.files) {
     EXPECT_EQ(f, "<test>");
   }
+}
+
+TEST_F(DebuggerTest, OptimizedArgumentsAreMaterializedForFrameInspection) {
+  TraceState st;
+  st.inspectOnDebuggerStmt = true;
+  JS_SetDebugTraceHandler(ctx_, traceCb, &st);
+
+  JSValue v =
+      eval("function f(a) { arguments.length; debugger; return a; } f(7)");
+  JS_FreeValue(ctx_, v);
+
+  auto it = std::find_if(
+      st.locals.begin(), st.locals.end(), [](const std::string &local) {
+        return local.rfind("arguments=", 0) == 0;
+      });
+  ASSERT_NE(it, st.locals.end());
+  EXPECT_NE(*it, "arguments=undefined");
 }
 
 #endif  // JS_ENABLE_DEBUGGER

--- a/tests/differential/corpus/pr1-argument-fastpaths.js
+++ b/tests/differential/corpus/pr1-argument-fastpaths.js
@@ -1,0 +1,36 @@
+function out(name, value) {
+  print(name + ':' + String(value));
+}
+
+function mapped(a, b) {
+  a = a + 1;
+  return [arguments.length, arguments[0], arguments[1]];
+}
+out('mapped', mapped(4, 5, 6).join(','));
+
+function forwarded(a, b) {
+  return Math.max.apply(null, arguments);
+}
+out('forwarded', forwarded(3, 8, 2));
+
+function missing(a, b) {
+  return arguments.length + ':' + String(arguments[1]);
+}
+out('missing', missing(1));
+out('excess', missing(1, 2, 3));
+
+function closure(a) {
+  return function () { return a + arguments.length; };
+}
+out('closure', closure(7)(1, 2));
+
+function evaluated(a) {
+  return eval('arguments[0]') + a;
+}
+out('eval', evaluated(6));
+
+async function async_value(a) { return arguments.length + a; }
+async_value(5).then(function (v) { out('async', v); });
+
+function* generator_value(a) { yield arguments.length + a; }
+out('generator', generator_value(9).next().value);

--- a/tools/benchmark/calls.c
+++ b/tools/benchmark/calls.c
@@ -50,6 +50,20 @@ static JSValue c_gen_magic(
   (void)magic;
   return JS_UNDEFINED;
 }
+/* A class-call object: the shape a JSI HostFunction presents to the engine.
+   Reaches the same js_call_c_function_fast() dispatch as c0..c8, but invokes
+   the class call slot directly instead of js_call_c_function(). */
+static JSValue c_class_call(
+    JSContext *ctx, JSValueConst func_obj, JSValueConst this_val, int argc,
+    JSValueConst *argv, int flags) {
+  (void)ctx;
+  (void)func_obj;
+  (void)this_val;
+  (void)argc;
+  (void)argv;
+  (void)flags;
+  return JS_UNDEFINED;
+}
 static JSValue c_data(
     JSContext *ctx, JSValueConst t, int argc, JSValueConst *argv, int magic,
     JSValue *data) {
@@ -169,7 +183,8 @@ static const char *KNOWN[] = {
     "ret_strnew",  "ret_obj",   "arg_int",  "arg_dbl",    "arg_str",
     "apply1",      "apply4",    "apply8",   "jsapply4",   "spread0",
     "spread1",     "spread4",   "spread8",  "applyargs4", "applygen4",
-    "applyacc4",   "jsspread4", NULL};
+    "applyacc4",   "jsspread4", "cc0",      "cc1",        "cc2",
+    "cc4",         "cc8",       NULL};
 
 static int is_known(const char *n) {
   for (int i = 0; KNOWN[i]; i++)
@@ -228,6 +243,20 @@ int main(int argc, char **argv) {
       ctx, g, "c4", JS_NewCFunction2(ctx, c_gen, "c4", 4, JS_CFUNC_generic, 0));
   JS_SetPropertyStr(
       ctx, g, "c8", JS_NewCFunction2(ctx, c_gen, "c8", 8, JS_CFUNC_generic, 0));
+  {
+    JSClassID cc_class_id = 0;
+    JSClassDef cc_def;
+    JS_NewClassID(rt, &cc_class_id);
+    memset(&cc_def, 0, sizeof(cc_def));
+    cc_def.class_name = "CCFunction";
+    cc_def.call = c_class_call;
+    if (JS_NewClass(rt, cc_class_id, &cc_def)) return 1;
+    JS_SetPropertyStr(ctx, g, "cc0", JS_NewObjectClass(ctx, cc_class_id));
+    JS_SetPropertyStr(ctx, g, "cc1", JS_NewObjectClass(ctx, cc_class_id));
+    JS_SetPropertyStr(ctx, g, "cc2", JS_NewObjectClass(ctx, cc_class_id));
+    JS_SetPropertyStr(ctx, g, "cc4", JS_NewObjectClass(ctx, cc_class_id));
+    JS_SetPropertyStr(ctx, g, "cc8", JS_NewObjectClass(ctx, cc_class_id));
+  }
   JSValue dat = JS_NewInt32(ctx, 1);
   JS_SetPropertyStr(
       ctx, g, "d0", JS_NewCFunctionData(ctx, c_data, 0, 0, 1, &dat));
@@ -347,6 +376,21 @@ int main(int argc, char **argv) {
     body = "f(1,2,3,4);";
   } else if (!strcmp(shape, "gen8")) {
     setup = "var f=g.c8;";
+    body = "f(1,2,3,4,5,6,7,8);";
+  } else if (!strcmp(shape, "cc0")) {
+    setup = "var f=g.cc0;";
+    body = "f();";
+  } else if (!strcmp(shape, "cc1")) {
+    setup = "var f=g.cc1;";
+    body = "f(1);";
+  } else if (!strcmp(shape, "cc2")) {
+    setup = "var f=g.cc2;";
+    body = "f(1,2);";
+  } else if (!strcmp(shape, "cc4")) {
+    setup = "var f=g.cc4;";
+    body = "f(1,2,3,4);";
+  } else if (!strcmp(shape, "cc8")) {
+    setup = "var f=g.cc8;";
     body = "f(1,2,3,4,5,6,7,8);";
   } else if (!strcmp(shape, "pad4x1")) {
     setup = "var f=g.c4;";


### PR DESCRIPTION
## Summary

Speeds up JavaScript → native calls in two places: five engine patches that remove
unnecessary work around native calls and argument arrays, and one JSI runtime change
that builds only the host-function arguments that were actually passed.

## Engine patches

- `0034` — dispatch interpreter-issued calls straight to supported native functions
  instead of entering the bytecode-call machinery first.
- `0035` — copy eligible dense array spreads directly into the argument accumulator
  instead of allocating and driving an iterator.
- `0036` — forward unchanged dense mapped `arguments` from their live parameter slots
  during `apply`.
- `0037` — skip argument-array copies for callees proven not to write, capture, expose
  or alias their argument slots.
- `0038` — avoid reifying `arguments` for safe `length` reads, indexed reads and
  builtin `apply`.

Every fast path keeps the existing fallback for observable or unsupported cases:
argument writes, mapped arguments, proxies, accessors, generators, custom iterators,
eval, and ordinary JavaScript-to-JavaScript calls.

## JSI host calls

`HostFunctionHandlers::call` used to default-construct all eight inline `jsi::Value`
slots, move-assign each argument into them, and then destroy all eight — most of that
work landed on slots no argument ever used. It now:

- builds exactly `argc` values in aligned raw storage,
- converts each QuickJS value directly into its final slot (no temporary, no
  move-assignment),
- inlines the conversion into the argument loop,
- keeps the more-than-eight vector fallback assigning into live elements, so a
  conversion that throws still leaves a destructible value behind.

## Performance

| Host call | `main` (pre-`0034`) | Branch tip | Change |
| --- | ---: | ---: | ---: |
| 0 arguments | 75.6 ns | 38.1 ns | −50% |
| 1 argument | 92.9 ns | 64.0 ns | −31% |
| 4 arguments | 120.2 ns | 82.2 ns | −32% |
| 8 arguments | 159.9 ns | 113.8 ns | −29% |
| 1 string argument | 98.8 ns | 68.5 ns | −31% |
| 1 object argument | 98.8 ns | 68.5 ns | −31% |

## Validation

- Complete CTest suite: 15/15.
- Focused JSI tests and the JSI conformance suite.
- Bytecode, differential, and runtime tests.
- `node scripts/apply-patches.js --check`
- `node scripts/sync-quickjs-rel.js --check`
- `git diff --check`
