### PR TITLE
perf: keep array methods on dense storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning][semver].
   live iterator also costs one fewer malloc and 32 bytes. The sampled Octane
   rows are flat (10-row geomean -0.27%), because those rows iterate with
   indexed loops rather than `for...of`.
+- Patch `0044`: fills `Array.prototype.slice` and `splice` results directly into
+  the dense result array instead of defining every index through the generic
+  path. On-device, slicing a 200-element packed array is 74% faster, a
+  50-element window of it 70%, and a 100,000-element array 70%, with an
+  array-like source and an empty result unchanged. The sampled Octane rows are
+  flat (8-row geomean -0.04%).
 - Host-function calls now build only the arguments actually passed, instead of
   materialising all eight inline slots, and the QuickJS value conversion is
   inlined into the argument loop. Measured against the same branch without this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning][semver].
   mapping to objects 11.7% faster. The sampled Octane rows are neutral overall
   (geomean -0.49%), the largest moves being deltablue -1.76% and richards
   -1.29%, which measure as code layout rather than the added check.
+- Patch `0042`: gives fast arrays a hole representation instead of demoting the
+  object to a property table when an index is skipped or deleted. On-device the
+  crypto row of Octane is 23.4% faster and pdfjs 20.4% faster, the two rows
+  whose element accesses previously landed on a demoted array; the other
+  sampled rows are flat (8-row geomean +5.3%). Filling from index 2 is 52.8%
+  faster and deleting every other element 17.7%; a reverse fill is unchanged.
 - Host-function calls now build only the arguments actually passed, instead of
   materialising all eight inline slots, and the QuickJS value conversion is
   inlined into the argument loop. Measured against the same branch without this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ and this project adheres to [Semantic Versioning][semver].
   50-element window of it 70%, and a 100,000-element array 70%, with an
   array-like source and an empty result unchanged. The sampled Octane rows are
   flat (8-row geomean -0.04%).
+- Patch `0045`: copies `Array.prototype.concat` inputs that are already dense
+  fast arrays straight into the result instead of reading and defining every
+  element. On-device, concatenating two 200-element arrays is 85% faster, four
+  100-element arrays 80%, a scalar 81% and two 20,000-element arrays 74%, with
+  an input pair that keeps the generic path unchanged. The sampled Octane rows
+  are flat (8-row geomean +0.21%).
 - Host-function calls now build only the arguments actually passed, instead of
   materialising all eight inline slots, and the QuickJS value conversion is
   inlined into the argument loop. Measured against the same branch without this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning][semver].
   100-element arrays 80%, a scalar 81% and two 20,000-element arrays 74%, with
   an input pair that keeps the generic path unchanged. The sampled Octane rows
   are flat (8-row geomean +0.21%).
+- Patch `0046`: reserves capacity for the `Array.prototype.filter` result from
+  the input length, capped at 4096 slots, before the callback loop. On-device,
+  filtering a 200-element array is 8.3% faster and a 100,000-element array
+  7.6%; a filter that keeps nothing pays about 1%, and a live result can hold
+  up to 32 KB of reserved storage that its `length` does not expose. The
+  sampled Octane rows are flat (8-row geomean -0.32%).
 - Host-function calls now build only the arguments actually passed, instead of
   materialising all eight inline slots, and the QuickJS value conversion is
   inlined into the argument loop. Measured against the same branch without this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning][semver].
   with a syntax error.
 - Patch `0040`: assigns the C-function frame argument buffer, which was
   previously left uninitialized.
+- Patch `0041`: appends `Array.prototype.map` and `filter` results directly to
+  the dense result array instead of walking the generic define path per
+  element. On-device, `map` identity is 25.2% faster, `filter` 19.9% faster and
+  mapping to objects 11.7% faster. The sampled Octane rows are neutral overall
+  (geomean -0.49%), the largest moves being deltablue -1.76% and richards
+  -1.29%, which measure as code layout rather than the added check.
 - Host-function calls now build only the arguments actually passed, instead of
   materialising all eight inline slots, and the QuickJS value conversion is
   inlined into the argument loop. Measured against the same branch without this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning][semver].
   whose element accesses previously landed on a demoted array; the other
   sampled rows are flat (8-row geomean +5.3%). Filling from index 2 is 52.8%
   faster and deleting every other element 17.7%; a reverse fill is unchanged.
+- Patch `0043`: steps array iterators from the dense storage instead of
+  re-reading `length` and the element with two property gets, and stores the
+  iterator record inline instead of in its own allocation. On-device `for...of`
+  over an array is 33.3% faster, array destructuring 11.1%, `.values()` 8.1%,
+  `.entries()` 6.9% and `.keys()` 4.9%, with an indexed loop unchanged; each
+  live iterator also costs one fewer malloc and 32 bytes. The sampled Octane
+  rows are flat (10-row geomean -0.27%), because those rows iterate with
+  indexed loops rather than `for...of`.
 - Host-function calls now build only the arguments actually passed, instead of
   materialising all eight inline slots, and the QuickJS value conversion is
   inlined into the argument loop. Measured against the same branch without this

--- a/engine/patches/0041-array-map-filter-fast-append.patch
+++ b/engine/patches/0041-array-map-filter-fast-append.patch
@@ -1,0 +1,72 @@
+Subject: Append To Array Results Without The Generic Define Path
+
+What this does
+  Array.prototype.map and filter build their result by defining index 0, 1, 2,
+  ... in order. When that define is an exact append to a dense fast array, the
+  value is stored through add_fast_array_element instead of the generic
+  property-descriptor path.
+
+Why we need it
+  The generic route turns every index into an atom and re-derives, per element,
+  that this is an append to a dense array. map and filter are how list UIs
+  build their output.
+
+What it adds
+  The check runs per element and admits only an exact append to an ordinary
+  extensible dense array; everything else keeps the generic path, so a callback
+  that mutates the result stops qualifying mid-iteration. Both define entry
+  points map and filter use are covered.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -12765,11 +12765,34 @@
+     return ret;
+ }
+ 
++static JSObject *js_fast_array_append_target(JSValueConst this_obj,
++                                             int64_t idx, int flags)
++{
++    JSObject *p;
++
++    if ((flags & ~JS_PROP_THROW) != JS_PROP_C_W_E)
++        return NULL;
++    if (JS_VALUE_GET_TAG(this_obj) != JS_TAG_OBJECT)
++        return NULL;
++    p = JS_VALUE_GET_OBJ(this_obj);
++    if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || !p->extensible)
++        return NULL;
++    if (idx != (int64_t)p->u.array.count)
++        return NULL;
++    return p;
++}
++
+ int JS_DefinePropertyValueValue(JSContext *ctx, JSValueConst this_obj,
+                                 JSValue prop, JSValue val, int flags)
+ {
+     JSAtom atom;
+     int ret;
++    if (JS_VALUE_GET_TAG(prop) == JS_TAG_INT) {
++        JSObject *p = js_fast_array_append_target(
++            this_obj, JS_VALUE_GET_INT(prop), flags);
++        if (p != NULL)
++            return add_fast_array_element(ctx, p, val, flags) < 0 ? -1 : 0;
++    }
+     atom = JS_ValueToAtom(ctx, prop);
+     JS_FreeValue(ctx, prop);
+     if (unlikely(atom == JS_ATOM_NULL)) {
+@@ -12839,6 +12862,12 @@
+ {
+     JSAtom atom;
+     int ret;
++    if (idx <= INT32_MAX) {
++        JSObject *p = js_fast_array_append_target(this_obj, idx, flags);
++        if (p != NULL)
++            return add_fast_array_element(ctx, p, js_dup(val), flags) < 0
++                ? -1 : 0;
++    }
+     atom = JS_ValueToAtom(ctx, js_int64(idx));
+     if (unlikely(atom == JS_ATOM_NULL))
+         return -1;

--- a/engine/patches/0042-holey-fast-arrays.patch
+++ b/engine/patches/0042-holey-fast-arrays.patch
@@ -1,0 +1,443 @@
+Subject: Represent Array Holes Instead Of Demoting To A Property Table
+
+What this does
+  A fast array keeps its dense JSValue vector when an index is skipped or
+  deleted: the skipped slots hold JS_TAG_UNINITIALIZED and the object tracks
+  how many.  A gap store that would allocate too much vector, or a store from
+  a non-C_W_E descriptor, still demotes exactly as before.
+
+Why we need it
+  Upstream abandons the fast representation permanently the first time a store
+  lands past the end, so Array(n), a reverse fill, a row-offset matrix or a
+  delete turns every later access into a property-table lookup.
+
+What it adds
+  One flag bit and one uint32 inside padding the union already had, so
+  sizeof(JSObject) is unchanged and a static assert pins that.  Absence is
+  reported through the read funnel, own-property lookups, key lists, argument
+  lists and element copies; holes are skipped when demoting, so a delete is
+  not resurrected as undefined.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -1349,6 +1349,7 @@
+     uint8_t free_mark : 1; /* only used when freeing objects with cycles */
+     uint8_t is_exotic : 1; /* true if object has exotic property handlers */
+     uint8_t fast_array : 1; /* true if u.array is used for get/put (for JS_CLASS_ARRAY, JS_CLASS_ARGUMENTS, JS_CLASS_MAPPED_ARGUMENTS and typed arrays) */
++    uint8_t holey : 1;
+     uint8_t is_constructor : 1; /* true if object is a constructor function */
+     uint8_t is_uncatchable_error : 1; /* if true, error is not catchable */
+     uint8_t tmp_mark : 1; /* used in JS_WriteObjectRec() */
+@@ -1418,13 +1419,17 @@
+                 double *double_ptr;     /* JS_CLASS_FLOAT64_ARRAY */
+             } u;
+             uint32_t count; /* <= 2^31-1. 0 for a detached typed array */
+-        } array;    /* 12/20 bytes */
++            uint32_t hole_count; /* JS_CLASS_ARRAY only, valid while p->holey */
++        } array;    /* 16/24 bytes */
+         JSRegExp regexp;    /* JS_CLASS_REGEXP: 8/16 bytes */
+         JSValue object_data;    /* for JS_SetObjectData(): 8/16/16 bytes */
+     } u;
+     /* byte sizes: 40/48/72 */
+ };
+ 
++_Static_assert(sizeof(((JSObject *)0)->u.array) <= sizeof(((JSObject *)0)->u.func),
++               "u.array outgrew u.func");
++
+ typedef struct JSCallSiteData {
+     JSValue filename;
+     JSValue func;
+@@ -3198,6 +3203,11 @@
+     JS_FreeValue(ctx, old_val);
+ }
+ 
++static inline bool js_array_slot_is_hole(JSValueConst v)
++{
++    return JS_VALUE_GET_TAG(v) == JS_TAG_UNINITIALIZED;
++}
++
+ void JS_SetClassProto(JSContext *ctx, JSClassID class_id, JSValue obj)
+ {
+     assert(class_id < ctx->rt->class_count);
+@@ -7218,6 +7228,7 @@
+     p->free_mark = 0;
+     p->is_exotic = 0;
+     p->fast_array = 0;
++    p->holey = 0;
+     p->is_constructor = 0;
+     p->is_uncatchable_error = 0;
+     p->tmp_mark = 0;
+@@ -7251,6 +7262,7 @@
+             p->fast_array = 1;
+             p->u.array.u.values = NULL;
+             p->u.array.count = 0;
++            p->u.array.hole_count = 0;
+             p->u.array.u1.size = 0;
+             if (!props) {
+                 /* XXX: remove */
+@@ -10415,7 +10427,9 @@
+             if (p->fast_array) {
+                 if (__JS_AtomIsTaggedInt(prop)) {
+                     uint32_t idx = __JS_AtomToUInt32(prop);
+-                    if (idx < p->u.array.count) {
++                    if (idx < p->u.array.count &&
++                        !(p->holey &&
++                          js_array_slot_is_hole(p->u.array.u.values[idx]))) {
+                         /* we avoid duplicating the code */
+                         return JS_GetPropertyUint32(ctx, JS_MKPTR(JS_TAG_OBJECT, p), idx);
+                     } else if (is_typed_array(p->class_id)) {
+@@ -10787,6 +10801,8 @@
+         if (p->fast_array) {
+             if (flags & JS_GPN_STRING_MASK) {
+                 num_keys_count += p->u.array.count;
++                if (unlikely(p->holey))
++                    num_keys_count -= p->u.array.hole_count;
+             }
+         } else if (p->class_id == JS_CLASS_STRING) {
+             if (flags & JS_GPN_STRING_MASK) {
+@@ -10868,7 +10884,21 @@
+         if (p->fast_array) {
+             if (flags & JS_GPN_STRING_MASK) {
+                 len = p->u.array.count;
+-                goto add_array_keys;
++                if (unlikely(p->holey)) {
++                    for(i = 0; i < len; i++) {
++                        if (js_array_slot_is_hole(p->u.array.u.values[i]))
++                            continue;
++                        tab_atom[num_index].atom = __JS_AtomFromUInt32(i);
++                        if (tab_atom[num_index].atom == JS_ATOM_NULL) {
++                            js_free_prop_enum(ctx, tab_atom, num_index);
++                            return -1;
++                        }
++                        tab_atom[num_index].is_enumerable = true;
++                        num_index++;
++                    }
++                } else {
++                    goto add_array_keys;
++                }
+             }
+         } else if (p->class_id == JS_CLASS_STRING) {
+             if (flags & JS_GPN_STRING_MASK) {
+@@ -10998,7 +11028,9 @@
+             if (__JS_AtomIsTaggedInt(prop)) {
+                 uint32_t idx;
+                 idx = __JS_AtomToUInt32(prop);
+-                if (idx < p->u.array.count) {
++                if (idx < p->u.array.count &&
++                    !(p->holey &&
++                      js_array_slot_is_hole(p->u.array.u.values[idx]))) {
+                     if (desc) {
+                         desc->flags = JS_PROP_WRITABLE | JS_PROP_ENUMERABLE |
+                             JS_PROP_CONFIGURABLE;
+@@ -11183,6 +11215,18 @@
+ {
+     switch(p->class_id) {
+     case JS_CLASS_ARRAY:
++        {
++            JSValue v;
++            if (unlikely(idx >= p->u.array.count)) return false;
++            v = p->u.array.u.values[idx];
++            if (unlikely(JS_VALUE_GET_TAG(v) == JS_TAG_UNINITIALIZED))
++                return false;
++            if (js_lazy_marker_is(v))
++                *pval = js_lazy_materialize_slot(ctx, &p->u.array.u.values[idx], p);
++            else
++                *pval = js_dup(v);
++            return true;
++        }
+     case JS_CLASS_ARGUMENTS:
+         if (unlikely(idx >= p->u.array.count)) return false;
+         if (js_lazy_marker_is(p->u.array.u.values[idx]))
+@@ -11451,17 +11495,22 @@
+     } else {
+         JSValue *tab = p->u.array.u.values;
+         for(i = 0; i < len; i++) {
++            JSValue v = *tab++;
++            if (unlikely(js_array_slot_is_hole(v)))
++                continue;
+             /* add_property cannot fail here but
+                __JS_AtomFromUInt32(i) fails for i > INT32_MAX */
+             pr = add_property(ctx, p, __JS_AtomFromUInt32(i), JS_PROP_C_W_E);
+-            pr->u.value = *tab++;
++            pr->u.value = v;
+         }
+     }
+     js_free(ctx, p->u.array.u.values);
+     p->u.array.count = 0;
++    p->u.array.hole_count = 0;
+     p->u.array.u.values = NULL; /* fail safe */
+     p->u.array.u1.size = 0;
+     p->fast_array = 0;
++    p->holey = 0;
+     return 0;
+ }
+ 
+@@ -11529,8 +11578,20 @@
+             uint32_t idx;
+             if (JS_AtomIsArrayIndex(ctx, &idx, atom) &&
+                 idx < p->u.array.count) {
+-                if (p->class_id == JS_CLASS_ARRAY ||
+-                    p->class_id == JS_CLASS_ARGUMENTS ||
++                if (p->class_id == JS_CLASS_ARRAY) {
++                    JSValue v = p->u.array.u.values[idx];
++                    if (js_array_slot_is_hole(v))
++                        return true;              /* already absent */
++                    p->u.array.u.values[idx] = JS_UNINITIALIZED;
++                    if (!p->holey) {
++                        p->holey = 1;
++                        p->u.array.hole_count = 0;
++                    }
++                    p->u.array.hole_count++;
++                    JS_FreeValue(ctx, v);
++                    return true;
++                }
++                if (p->class_id == JS_CLASS_ARGUMENTS ||
+                     p->class_id == JS_CLASS_MAPPED_ARGUMENTS) {
+                     if (convert_fast_array_to_array(ctx, p))
+                         return -1;
+@@ -11594,6 +11655,11 @@
+         uint32_t old_len = p->u.array.count;
+         if (len < old_len) {
+             for(i = len; i < old_len; i++) {
++                if (unlikely(p->holey) &&
++                    js_array_slot_is_hole(p->u.array.u.values[i])) {
++                    if (--p->u.array.hole_count == 0)
++                        p->holey = 0;
++                }
+                 JS_FreeValue(ctx, p->u.array.u.values[i]);
+                 p->u.array.u.values[i] = JS_UNDEFINED;
+             }
+@@ -11723,6 +11789,88 @@
+     p->u.array.u.values[new_len - 1] = val;
+     p->u.array.count = new_len;
+     return true;
++}
++
++
++#define JS_ARRAY_HOLE_MAX_GAP     256
++#define JS_ARRAY_HOLE_DENSE_FLOOR 256
++#define JS_ARRAY_HOLE_MIN_DENSITY 4
++
++static inline bool js_array_can_fill_hole_fast(JSContext *ctx, JSObject *p)
++{
++    return p->extensible &&
++        p->shape->proto == JS_VALUE_GET_OBJ(ctx->class_proto[JS_CLASS_ARRAY]) &&
++        ctx->std_array_prototype;
++}
++
++static int js_array_store_hole_gap(JSContext *ctx, JSObject *p, uint32_t idx,
++                                   JSValue val)
++{
++    uint32_t count, gap, new_count, elems, array_len, i;
++
++    count = p->u.array.count;
++    gap = idx - count;
++    if (gap > JS_ARRAY_HOLE_MAX_GAP)
++        return 0;
++    if (idx >= (uint32_t)INT32_MAX)
++        return 0;
++    new_count = idx + 1;
++    elems = new_count - ((p->holey ? p->u.array.hole_count : 0) + gap);
++    if (new_count > JS_ARRAY_HOLE_DENSE_FLOOR &&
++        elems * (uint64_t)JS_ARRAY_HOLE_MIN_DENSITY < new_count)
++        return 0;
++    if (unlikely(JS_VALUE_GET_TAG(p->prop[0].u.value) != JS_TAG_INT))
++        return 0;
++    array_len = JS_VALUE_GET_INT(p->prop[0].u.value);
++    if (new_count > array_len &&
++        unlikely(!(get_shape_prop(p->shape)->flags & JS_PROP_WRITABLE)))
++        return 0;
++    if (new_count > p->u.array.u1.size) {
++        if (expand_fast_array(ctx, p, new_count)) {
++            JS_FreeValue(ctx, val);
++            return -1;
++        }
++    }
++    for (i = count; i < idx; i++)
++        p->u.array.u.values[i] = JS_UNINITIALIZED;
++    p->u.array.u.values[idx] = val;
++    p->u.array.count = new_count;
++    if (new_count > array_len)
++        p->prop[0].u.value = js_int32(new_count);
++    if (!p->holey) {
++        p->holey = 1;
++        p->u.array.hole_count = 0;
++    }
++    p->u.array.hole_count += gap;
++    return 1;
++}
++
++static void js_array_fill_hole(JSObject *p, uint32_t idx, JSValue val)
++{
++    assert(p->holey && js_array_slot_is_hole(p->u.array.u.values[idx]));
++    p->u.array.u.values[idx] = val;
++    if (--p->u.array.hole_count == 0)
++        p->holey = 0;
++}
++
++static bool js_array_try_repack(JSObject *p)
++{
++    uint32_t i, count, holes;
++
++    if (p->u.array.hole_count == 0) {   /* kept exact; this is the usual exit */
++        p->holey = 0;
++        return true;
++    }
++    count = p->u.array.count;
++    holes = 0;
++    for (i = 0; i < count; i++)
++        holes += js_array_slot_is_hole(p->u.array.u.values[i]);
++    p->u.array.hole_count = holes;
++    if (holes == 0) {
++        p->holey = 0;
++        return true;
++    }
++    return false;
+ }
+ 
+ /* Allocate a new fast array initialized to JS_UNDEFINED. Its maximum
+@@ -11835,7 +11983,9 @@
+             if (p1->fast_array) {
+                 if (__JS_AtomIsTaggedInt(prop)) {
+                     uint32_t idx = __JS_AtomToUInt32(prop);
+-                    if (idx < p1->u.array.count) {
++                    if (idx < p1->u.array.count &&
++                        !(p1->holey &&
++                          js_array_slot_is_hole(p1->u.array.u.values[idx]))) {
+                         if (unlikely(p == p1))
+                             return JS_SetPropertyValue(ctx, this_obj, js_int32(idx), val, flags);
+                         else
+@@ -12065,6 +12215,13 @@
+                 /* add element */
+                 return add_fast_array_element(ctx, p, val, flags);
+             }
++            if (unlikely(p->holey) &&
++                js_array_slot_is_hole(p->u.array.u.values[idx])) {
++                if (unlikely(!js_array_can_fill_hole_fast(ctx, p)))
++                    goto slow_path;
++                js_array_fill_hole(p, idx, val);
++                break;
++            }
+             set_value(ctx, &p->u.array.u.values[idx], val);
+             break;
+         case JS_CLASS_ARGUMENTS:
+@@ -12274,6 +12431,24 @@
+                         return add_fast_array_element(ctx, p,
+                                                       js_dup(val), flags);
+                     } else {
++                        if (!p->extensible)
++                            goto not_extensible;
++                        if (flags & (JS_PROP_HAS_GET | JS_PROP_HAS_SET))
++                            goto convert_to_array;
++                        if (get_prop_flags(flags, 0) != JS_PROP_C_W_E)
++                            goto convert_to_array;
++                        if (idx < p->u.array.count) {
++                            assert(p->holey &&
++                                   js_array_slot_is_hole(p->u.array.u.values[idx]));
++                            js_array_fill_hole(p, idx, js_dup(val));
++                            return true;
++                        }
++                        ret = js_array_store_hole_gap(ctx, p, idx,
++                                                      js_dup(val));
++                        if (ret < 0)
++                            return -1;
++                        if (ret > 0)
++                            return true;
+                         goto convert_to_array;
+                     }
+                 } else if (JS_AtomIsArrayIndex(ctx, &idx, prop)) {
+@@ -12649,7 +12824,9 @@
+         if (p->class_id == JS_CLASS_ARRAY) {
+             if (__JS_AtomIsTaggedInt(prop)) {
+                 idx = __JS_AtomToUInt32(prop);
+-                if (idx < p->u.array.count) {
++                if (idx < p->u.array.count &&
++                    !(p->holey &&
++                      js_array_slot_is_hole(p->u.array.u.values[idx]))) {
+                     prop_flags = get_prop_flags(flags, JS_PROP_C_W_E);
+                     if (prop_flags != JS_PROP_C_W_E)
+                         goto convert_to_slow_array;
+@@ -18668,13 +18845,14 @@
+     if (JS_VALUE_GET_TAG(obj) == JS_TAG_OBJECT) {
+         JSObject *p = JS_VALUE_GET_OBJ(obj);
+         if (p->class_id == JS_CLASS_ARRAY && p->fast_array) {
++            if (unlikely(p->holey) && !js_array_try_repack(p))
++                return false;
+             return true;
+         }
+     }
+     return false;
+ }
+ 
+-/* Access an Array's internal JSValue array if available */
+ static bool js_get_fast_array(JSContext *ctx, JSValue obj,
+                               JSValue **arrpp, uint32_t *countp)
+ {
+@@ -18682,6 +18860,8 @@
+     if (JS_VALUE_GET_TAG(obj) == JS_TAG_OBJECT) {
+         JSObject *p = JS_VALUE_GET_OBJ(obj);
+         if (p->class_id == JS_CLASS_ARRAY && p->fast_array) {
++            if (unlikely(p->holey) && !js_array_try_repack(p))
++                return false;
+             *countp = p->u.array.count;
+             *arrpp = p->u.array.u.values;
+             return true;
+@@ -22024,7 +22204,8 @@
+                     JSObject *p = JS_VALUE_GET_OBJ(sp[-2]);
+                     uint32_t idx = JS_VALUE_GET_INT(sp[-1]);
+                     if (likely(p->class_id == JS_CLASS_ARRAY &&
+-                               idx < p->u.array.count)) {
++                               idx < p->u.array.count &&
++                               !js_array_slot_is_hole(p->u.array.u.values[idx]))) {
+                         if (js_lazy_marker_is(p->u.array.u.values[idx]))
+                             val = js_lazy_materialize_slot(ctx, &p->u.array.u.values[idx], p);
+                         else
+@@ -22061,7 +22242,8 @@
+                     JSObject *p = JS_VALUE_GET_OBJ(sp[-2]);
+                     uint32_t idx = JS_VALUE_GET_INT(sp[-1]);
+                     if (likely(p->class_id == JS_CLASS_ARRAY &&
+-                               idx < p->u.array.count)) {
++                               idx < p->u.array.count &&
++                               !js_array_slot_is_hole(p->u.array.u.values[idx]))) {
+                         if (js_lazy_marker_is(p->u.array.u.values[idx]))
+                             sp[-1] = js_lazy_materialize_slot(ctx, &p->u.array.u.values[idx], p);
+                         else
+@@ -22135,7 +22317,8 @@
+                     if (likely(JS_VALUE_GET_TAG(sp[-3]) == JS_TAG_OBJECT)) {
+                         p = JS_VALUE_GET_OBJ(sp[-3]);
+                         if (likely(p->class_id == JS_CLASS_ARRAY &&
+-                                   idx < (uint32_t)p->u.array.count)) {
++                                   idx < (uint32_t)p->u.array.count &&
++                                   !js_array_slot_is_hole(p->u.array.u.values[idx]))) {
+                             set_value(ctx, &p->u.array.u.values[idx], val);
+                             JS_FreeValue(ctx, sp[-3]);
+                             sp -= 3;
+@@ -46530,6 +46713,7 @@
+     p = JS_VALUE_GET_OBJ(array_arg);
+     if ((p->class_id == JS_CLASS_ARRAY || p->class_id == JS_CLASS_ARGUMENTS) &&
+         p->fast_array &&
++        !p->holey &&
+         len == p->u.array.count) {
+         for(i = 0; i < len; i++) {
+             tab[i] = js_dup(p->u.array.u.values[i]);
+@@ -47058,7 +47242,7 @@
+     p = NULL;
+     if (JS_VALUE_GET_TAG(obj) == JS_TAG_OBJECT) {
+         p = JS_VALUE_GET_OBJ(obj);
+-        if (p->class_id != JS_CLASS_ARRAY || !p->fast_array) {
++        if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || p->holey) {
+             p = NULL;
+         }
+     }
+@@ -47071,7 +47255,7 @@
+             from = from_pos + i;
+             to = to_pos + i;
+         }
+-        if (p && p->fast_array &&
++        if (p && p->fast_array && !p->holey &&
+             from >= 0 && from < (len = p->u.array.count)  &&
+             to >= 0 && to < len) {
+             int64_t l, j;

--- a/engine/patches/0043-array-iterator-fast-step.patch
+++ b/engine/patches/0043-array-iterator-fast-step.patch
@@ -1,0 +1,173 @@
+Subject: Step Array Iterators Without Re-Reading Length And Elements
+
+What this does
+  An array iterator keeps its record inside the iterator object instead of a
+  separate allocation, and js_array_iterator_next serves a step over a plain
+  dense array straight from that record: no property get of `length` and no
+  generic element get per step.
+
+Why we need it
+  Every step of `for...of`, of array destructuring, of spread and of
+  `.values()`/`.entries()`/`.keys()` performed a full property get for `length`
+  and another for the element.
+
+What it adds
+  The step is guarded by class, dense storage, the hole flag and a bounds test,
+  so a Proxy, a typed array, an arguments object, an accessor index, a hole or
+  an index past the dense storage all keep the existing path.  The inline
+  record removes one allocation per array and string iterator, and those two
+  classes are now excluded from the opaque-block accounting that the inline
+  record would otherwise inflate.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -1339,6 +1339,12 @@
+     JSObject *proto;
+     uint32_t hash_table[]; /* prop_hash_mask + 1 elements, then prop[prop_size] */
+ };
++
++typedef struct JSArrayIteratorData {
++    JSValue obj;
++    JSIteratorKindEnum kind;
++    uint32_t idx;
++} JSArrayIteratorData;
+ 
+ struct JSObject {
+     /* ref_count/gc_obj_type/mark live in the allocator block header; the object
+@@ -1371,7 +1377,7 @@
+         struct JSTypedArray *typed_array; /* JS_CLASS_UINT8C_ARRAY..JS_CLASS_DATAVIEW */
+         struct JSMapState *map_state;   /* JS_CLASS_MAP..JS_CLASS_WEAKSET */
+         struct JSMapIteratorData *map_iterator_data; /* JS_CLASS_MAP_ITERATOR, JS_CLASS_SET_ITERATOR */
+-        struct JSArrayIteratorData *array_iterator_data; /* JS_CLASS_ARRAY_ITERATOR, JS_CLASS_STRING_ITERATOR */
++        JSArrayIteratorData array_iterator_data; /* JS_CLASS_ARRAY_ITERATOR, JS_CLASS_STRING_ITERATOR */
+         struct JSRegExpStringIteratorData *regexp_string_iterator_data; /* JS_CLASS_REGEXP_STRING_ITERATOR */
+         struct JSGeneratorData *generator_data; /* JS_CLASS_GENERATOR */
+         struct JSIteratorConcatData *iterator_concat_data; /* JS_CLASS_ITERATOR_CONCAT */
+@@ -9027,8 +9033,9 @@
+         case JS_CLASS_WEAKSET:           /* u.map_state */
+         case JS_CLASS_MAP_ITERATOR:      /* u.map_iterator_data */
+         case JS_CLASS_SET_ITERATOR:      /* u.map_iterator_data */
+-        case JS_CLASS_ARRAY_ITERATOR:    /* u.array_iterator_data */
+-        case JS_CLASS_STRING_ITERATOR:   /* u.array_iterator_data */
++        case JS_CLASS_ARRAY_ITERATOR:    /* u.array_iterator_data, stored inline */
++        case JS_CLASS_STRING_ITERATOR:   /* no separate block to account for */
++            break;
+         case JS_CLASS_PROXY:             /* u.proxy_data */
+         case JS_CLASS_PROMISE:           /* u.promise_data */
+         case JS_CLASS_PROMISE_RESOLVE_FUNCTION:  /* u.promise_function_data */
+@@ -49121,30 +49128,20 @@
+     return ret;
+ }
+ 
+-typedef struct JSArrayIteratorData {
+-    JSValue obj;
+-    JSIteratorKindEnum kind;
+-    uint32_t idx;
+-} JSArrayIteratorData;
+-
+ static void js_array_iterator_finalizer(JSRuntime *rt, JSValueConst val)
+ {
+     JSObject *p = JS_VALUE_GET_OBJ(val);
+-    JSArrayIteratorData *it = p->u.array_iterator_data;
+-    if (it) {
+-        JS_FreeValueRT(rt, it->obj);
+-        js_free_rt(rt, it);
+-    }
++    JSArrayIteratorData *it = &p->u.array_iterator_data;
++    JS_FreeValueRT(rt, it->obj);
++    it->obj = JS_UNDEFINED;
+ }
+ 
+ static void js_array_iterator_mark(JSRuntime *rt, JSValueConst val,
+                                    JS_MarkFunc *mark_func)
+ {
+     JSObject *p = JS_VALUE_GET_OBJ(val);
+-    JSArrayIteratorData *it = p->u.array_iterator_data;
+-    if (it) {
+-        JS_MarkValue(rt, it->obj, mark_func);
+-    }
++    JSArrayIteratorData *it = &p->u.array_iterator_data;
++    JS_MarkValue(rt, it->obj, mark_func);
+ }
+ 
+ static JSValue js_create_array(JSContext *ctx, int len, JSValueConst *tab)
+@@ -49193,16 +49190,11 @@
+     enum_obj = JS_NewObjectClass(ctx, class_id);
+     if (JS_IsException(enum_obj))
+         goto fail;
+-    it = js_malloc(ctx, sizeof(*it));
+-    if (!it)
+-        goto fail1;
++    it = &JS_VALUE_GET_OBJ(enum_obj)->u.array_iterator_data;
+     it->obj = arr;
+     it->kind = kind;
+     it->idx = 0;
+-    JS_SetOpaqueInternal(enum_obj, it);
+     return enum_obj;
+- fail1:
+-    JS_FreeValue(ctx, enum_obj);
+  fail:
+     JS_FreeValue(ctx, arr);
+     return JS_EXCEPTION;
+@@ -49217,11 +49209,43 @@
+     JSValue val, obj;
+     JSObject *p;
+ 
+-    it = JS_GetOpaque2(ctx, this_val, JS_CLASS_ARRAY_ITERATOR);
++    if (likely(JS_VALUE_GET_TAG(this_val) == JS_TAG_OBJECT &&
++               JS_VALUE_GET_OBJ(this_val)->class_id == JS_CLASS_ARRAY_ITERATOR)) {
++        it = &JS_VALUE_GET_OBJ(this_val)->u.array_iterator_data;
++    } else {
++        it = JS_GetOpaque2(ctx, this_val, JS_CLASS_ARRAY_ITERATOR);
++    }
+     if (!it)
+         goto fail1;
+     if (JS_IsUndefined(it->obj))
+         goto done;
++    {
++        JSObject *ap = JS_VALUE_GET_OBJ(it->obj);
++        if (likely(ap->class_id == JS_CLASS_ARRAY && ap->fast_array &&
++                   !ap->holey && it->idx < ap->u.array.count)) {
++            uint32_t i2 = it->idx;
++            it->idx = i2 + 1;
++            *pdone = false;
++            if (it->kind == JS_ITERATOR_KIND_KEY)
++                return js_uint32(i2);
++            if (js_lazy_marker_is(ap->u.array.u.values[i2]))
++                val = js_lazy_materialize_slot(ctx, &ap->u.array.u.values[i2], ap);
++            else
++                val = js_dup(ap->u.array.u.values[i2]);
++            if (it->kind == JS_ITERATOR_KIND_VALUE)
++                return val;
++            {
++                JSValueConst args2[2];
++                JSValue num2 = js_uint32(i2);
++                args2[0] = num2;
++                args2[1] = val;
++                obj = js_create_array(ctx, 2, args2);
++                JS_FreeValue(ctx, val);
++                JS_FreeValue(ctx, num2);
++                return obj;
++            }
++        }
++    }
+     p = JS_VALUE_GET_OBJ(it->obj);
+     if (is_typed_array(p->class_id)) {
+         if (typed_array_is_oob(p)) {
+@@ -52657,7 +52681,12 @@
+     uint32_t idx, c, start;
+     JSString *p;
+ 
+-    it = JS_GetOpaque2(ctx, this_val, JS_CLASS_STRING_ITERATOR);
++    if (likely(JS_VALUE_GET_TAG(this_val) == JS_TAG_OBJECT &&
++               JS_VALUE_GET_OBJ(this_val)->class_id == JS_CLASS_STRING_ITERATOR)) {
++        it = &JS_VALUE_GET_OBJ(this_val)->u.array_iterator_data;
++    } else {
++        it = JS_GetOpaque2(ctx, this_val, JS_CLASS_STRING_ITERATOR);
++    }
+     if (!it) {
+         *pdone = false;
+         return JS_EXCEPTION;

--- a/engine/patches/0044-array-slice-direct-fill.patch
+++ b/engine/patches/0044-array-slice-direct-fill.patch
@@ -1,0 +1,55 @@
+Subject: Fill Array Slice And Splice Results Directly
+
+What this does
+  When `Array.prototype.slice` -- and `splice`, which shares the same code --
+  copies a range of an ordinary dense array into an ordinary dense result, it
+  grows the result's value buffer once and fills it element by element instead
+  of defining every index through JS_CreateDataPropertyUint32Const.
+
+Why we need it
+  The define path re-derives, for every element, that the index is an append to
+  a dense array, and it cannot see that the result was just created with exactly
+  the length being filled. Copying a list to render, filter or paginate it is an
+  everyday React Native shape.
+
+What it adds
+  The fill is guarded: the result must be an ordinary extensible dense array
+  with no elements yet, an integer length equal to the count, and either enough
+  capacity or one successful grow. The whole source range must lie inside the
+  source's dense storage, so a holey or inherited tail keeps the existing
+  per-index path -- as do an array-like source, a species result that is frozen
+  or pre-filled or has a locked length, and a species that returns the source
+  itself.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -48650,9 +48650,23 @@
+     if (js_get_fast_array(ctx, obj, &arrp, &count32) &&
+         js_is_fast_array(ctx, arr)) {
+         /* XXX: should share code with fast array constructor */
+-        for (; k < final && k < count32; k++, n++) {
+-            if (JS_CreateDataPropertyUint32Const(ctx, arr, n, arrp[k], JS_PROP_THROW) < 0)
+-                goto exception;
++        JSObject *ap = JS_VALUE_GET_OBJ(arr);
++        if (count > 0 && count <= INT32_MAX && final <= (int64_t)count32 &&
++            ap->extensible && ap->u.array.count == 0 &&
++            JS_VALUE_GET_TAG(ap->prop[0].u.value) == JS_TAG_INT &&
++            JS_VALUE_GET_INT(ap->prop[0].u.value) == count &&
++            (ap->u.array.u1.size >= (uint32_t)count ||
++             expand_fast_array(ctx, ap, count) == 0)) {
++            for (i = 0; i < (uint32_t)count; i++)
++                ap->u.array.u.values[i] = js_dup(arrp[start + i]);
++            ap->u.array.count = count;
++            n = count;
++            k = final;
++        } else {
++            for (; k < final && k < count32; k++, n++) {
++                if (JS_CreateDataPropertyUint32Const(ctx, arr, n, arrp[k], JS_PROP_THROW) < 0)
++                    goto exception;
++            }
+         }
+     }
+     /* Copy the remaining elements if any (handle case of inherited properties) */

--- a/engine/patches/0045-array-concat-direct-copy.patch
+++ b/engine/patches/0045-array-concat-direct-copy.patch
@@ -1,0 +1,139 @@
+Subject: Copy Concat Inputs That Are Already Dense
+
+What this does
+  `Array.prototype.concat` copies a packed dense fast array straight into the
+  result's value buffer, growing it once per input, instead of reading every
+  element with a generic property get and defining it back with a generic
+  define.
+
+Why we need it
+  The element get and the element define both re-derive, per element, that this
+  is an ordinary dense array read followed by an append to a dense array, when
+  the input is already dense storage.
+
+What it adds
+  The copy is used only when the element reads cannot be observed: the input
+  must be an ordinary dense fast array whose dense storage covers its whole
+  length, so every index is an own data property and no prototype, hole or
+  accessor can be reached. The result must be an ordinary extensible dense array
+  with no elements, an integer length and a writable `length`. A hole, an
+  array-like, a pre-filled or frozen species result, and a species that returns
+  the receiver all keep the existing per-element path unchanged.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -47642,13 +47642,71 @@
+     JS_FreeValue(ctx, arr);
+     JS_FreeValue(ctx, obj);
+     return ret;
++}
++
++static JSObject *js_concat_direct_target(JSValueConst arr)
++{
++    JSObject *p;
++
++    if (JS_VALUE_GET_TAG(arr) != JS_TAG_OBJECT)
++        return NULL;
++    p = JS_VALUE_GET_OBJ(arr);
++    if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || !p->extensible)
++        return NULL;
++    if (p->holey || p->u.array.count != 0)
++        return NULL;
++    if (!(get_shape_prop(p->shape)->flags & JS_PROP_WRITABLE))
++        return NULL;
++    if (JS_VALUE_GET_TAG(p->prop[0].u.value) != JS_TAG_INT ||
++        JS_VALUE_GET_INT(p->prop[0].u.value) != 0)
++        return NULL;
++    return p;
++}
++
++static int js_concat_direct_append(JSContext *ctx, JSObject *p, int64_t n,
++                                   JSValueConst e)
++{
++    if (p->holey || p->u.array.count != (uint32_t)n || n >= INT32_MAX)
++        return 0;
++    if (p->u.array.u1.size <= (uint32_t)n &&
++        expand_fast_array(ctx, p, (uint32_t)n + 1) < 0)
++        return -1;
++    p->u.array.u.values[n] = js_dup(e);
++    p->u.array.count = (uint32_t)n + 1;
++    set_value(ctx, &p->prop[0].u.value, js_int32(n + 1));
++    return 1;
+ }
+ 
++static int js_concat_direct_spread(JSContext *ctx, JSObject *p, int64_t n,
++                                   JSValueConst e, int64_t len)
++{
++    JSValue *arrp;
++    uint32_t count32, i;
++
++    if (len <= 0)
++        return 0;
++    if (p->holey || p->u.array.count != (uint32_t)n || n + len > INT32_MAX)
++        return 0;
++    if (JS_VALUE_GET_TAG(e) == JS_TAG_OBJECT && JS_VALUE_GET_OBJ(e) == p)
++        return 0;
++    if (!js_get_fast_array(ctx, e, &arrp, &count32) || (int64_t)count32 != len)
++        return 0;
++    if (p->u.array.u1.size < (uint32_t)(n + len) &&
++        expand_fast_array(ctx, p, (uint32_t)(n + len)) < 0)
++        return -1;
++    for (i = 0; i < (uint32_t)len; i++)
++        p->u.array.u.values[n + i] = js_dup(arrp[i]);
++    p->u.array.count = (uint32_t)(n + len);
++    set_value(ctx, &p->prop[0].u.value, js_int32(n + len));
++    return 1;
++}
++
+ static JSValue js_array_concat(JSContext *ctx, JSValueConst this_val,
+                                int argc, JSValueConst *argv)
+ {
+     JSValue obj, arr, val;
+     JSValueConst e;
++    JSObject *dp;
+     int64_t len, k, n;
+     int i, res;
+ 
+@@ -47660,6 +47718,7 @@
+     arr = JS_ArraySpeciesCreate(ctx, obj, js_int32(0));
+     if (JS_IsException(arr))
+         goto exception;
++    dp = js_concat_direct_target(arr);
+     n = 0;
+     for (i = -1; i < argc; i++) {
+         if (i < 0)
+@@ -47677,6 +47736,15 @@
+                 JS_ThrowTypeError(ctx, "Array loo long");
+                 goto exception;
+             }
++            if (dp != NULL) {
++                res = js_concat_direct_spread(ctx, dp, n, e, len);
++                if (res < 0)
++                    goto exception;
++                if (res) {
++                    n += len;
++                    continue;
++                }
++            }
+             for (k = 0; k < len; k++, n++) {
+                 res = JS_TryGetPropertyInt64(ctx, e, k, &val);
+                 if (res < 0)
+@@ -47692,6 +47760,15 @@
+                 JS_ThrowTypeError(ctx, "Array loo long");
+                 goto exception;
+             }
++            if (dp != NULL) {
++                res = js_concat_direct_append(ctx, dp, n, e);
++                if (res < 0)
++                    goto exception;
++                if (res) {
++                    n++;
++                    continue;
++                }
++            }
+             if (JS_DefinePropertyValueInt64Const(ctx, arr, n, e,
+                                                  JS_PROP_C_W_E | JS_PROP_THROW) < 0)
+                 goto exception;

--- a/engine/patches/0046-array-filter-reserve-capacity.patch
+++ b/engine/patches/0046-array-filter-reserve-capacity.patch
@@ -1,0 +1,57 @@
+Subject: Reserve Filter Result Capacity Before The Callback Loop
+
+What this does
+  `Array.prototype.filter` reserves fast-array capacity for its result from the
+  input length, capped at 4096 slots, before running the callback.
+
+Why we need it
+  The result starts empty and grows as the callback keeps elements, so a filter
+  that keeps most of its input reallocates and copies its storage repeatedly,
+  although the final size is already known to be at most the input length.
+
+What it adds
+  Capacity only: the result's element count and `length` are untouched, so the
+  reserved slots are not observable through `length`, `in` or iteration, and a
+  filter that keeps nothing pays for one reservation. A result that is not an
+  ordinary extensible fast array, or that already holds elements, is left
+  alone.
+
+Needs a bytecode version bump
+  No
+
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -47793,7 +47793,25 @@
+ #define special_map      3
+ #define special_filter   4
+ #define special_TA       8
++
++#define JS_FILTER_RESERVE_MAX 4096
+ 
++static void js_filter_reserve(JSContext *ctx, JSValueConst ret, int64_t len)
++{
++    JSObject *p;
++    int64_t cap;
++
++    if (JS_VALUE_GET_TAG(ret) != JS_TAG_OBJECT)
++        return;
++    p = JS_VALUE_GET_OBJ(ret);
++    if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || !p->extensible ||
++        p->holey || p->u.array.count != 0)
++        return;
++    cap = len < JS_FILTER_RESERVE_MAX ? len : JS_FILTER_RESERVE_MAX;
++    if (cap > 0 && p->u.array.u1.size < (uint32_t)cap)
++        expand_fast_array(ctx, p, (uint32_t)cap);
++}
++
+ static JSObject *get_typed_array(JSContext *ctx, JSValueConst this_val)
+ {
+     JSObject *p;
+@@ -47882,6 +47900,7 @@
+         ret = JS_ArraySpeciesCreate(ctx, obj, js_int32(0));
+         if (JS_IsException(ret))
+             goto exception;
++        js_filter_reserve(ctx, ret, len);
+         break;
+     case special_map | special_TA:
+         args[0] = obj;

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -55,6 +55,7 @@ what we changed and why without opening a single `.patch` file.
 | `0042` | Keeps an array dense when an index is skipped or deleted, by storing holes and tracking how many | Upstream demotes the array to a property table permanently the first time a store lands past the end, so `Array(n)`, gap fills, row-offset matrices and `delete` cost every later access | - | No |
 | `0043` | Stores the array/string iterator record inline and steps array iterators from the dense storage | Every iteration step re-read `length` with a property get and the element with a generic get; each iterator also allocated a record | - | No |
 | `0044` | Fills `slice` and `splice` results directly into the dense result array | The generic define path re-derives per element that the index appends to a dense array, and cannot see that the result was created with exactly that length | - | No |
+| `0045` | Copies `concat` inputs that are already dense fast arrays straight into the result | The per-element get and define re-derive that this is an ordinary dense read followed by an append to a dense array, when the input is already dense storage | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -56,6 +56,7 @@ what we changed and why without opening a single `.patch` file.
 | `0043` | Stores the array/string iterator record inline and steps array iterators from the dense storage | Every iteration step re-read `length` with a property get and the element with a generic get; each iterator also allocated a record | - | No |
 | `0044` | Fills `slice` and `splice` results directly into the dense result array | The generic define path re-derives per element that the index appends to a dense array, and cannot see that the result was created with exactly that length | - | No |
 | `0045` | Copies `concat` inputs that are already dense fast arrays straight into the result | The per-element get and define re-derive that this is an ordinary dense read followed by an append to a dense array, when the input is already dense storage | - | No |
+| `0046` | Reserves capped fast-array capacity for the `filter` result before the callback loop | The result starts empty and grows while the callback keeps elements, reallocating and copying storage repeatedly although the final size is known to be at most the input length | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -52,6 +52,7 @@ what we changed and why without opening a single `.patch` file.
 | `0039` | Keeps a pending exception when a formal parameter fails to parse | A stack overflow, interrupt or allocation failure raised while reading the parameter token is the real error; replacing it with "missing formal parameter" hides the cause and makes the reported failure depend on native stack depth | - | No |
 | `0040` | Assigns the C-function frame argument buffer | `js_call_c_function_data` and `js_call_c_closure` published a frame whose `arg_buf` was never set, so anything that walks frames precisely read an uninitialized buffer | - | No |
 | `0041` | Appends map and filter results directly to the dense result array | The generic define path turns every result index into an atom and re-derives, per element, that this is an append to a dense array | - | No |
+| `0042` | Keeps an array dense when an index is skipped or deleted, by storing holes and tracking how many | Upstream demotes the array to a property table permanently the first time a store lands past the end, so `Array(n)`, gap fills, row-offset matrices and `delete` cost every later access | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -53,6 +53,7 @@ what we changed and why without opening a single `.patch` file.
 | `0040` | Assigns the C-function frame argument buffer | `js_call_c_function_data` and `js_call_c_closure` published a frame whose `arg_buf` was never set, so anything that walks frames precisely read an uninitialized buffer | - | No |
 | `0041` | Appends map and filter results directly to the dense result array | The generic define path turns every result index into an atom and re-derives, per element, that this is an append to a dense array | - | No |
 | `0042` | Keeps an array dense when an index is skipped or deleted, by storing holes and tracking how many | Upstream demotes the array to a property table permanently the first time a store lands past the end, so `Array(n)`, gap fills, row-offset matrices and `delete` cost every later access | - | No |
+| `0043` | Stores the array/string iterator record inline and steps array iterators from the dense storage | Every iteration step re-read `length` with a property get and the element with a generic get; each iterator also allocated a record | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -51,6 +51,7 @@ what we changed and why without opening a single `.patch` file.
 | `0038` | Avoids reifying frame-visible mapped arguments for length, indexed reads, and verified builtin apply calls | Non-escaping argument uses can read the active frame without allocating an arguments object, while all observable slow paths retain the ordinary object | - | Yes |
 | `0039` | Keeps a pending exception when a formal parameter fails to parse | A stack overflow, interrupt or allocation failure raised while reading the parameter token is the real error; replacing it with "missing formal parameter" hides the cause and makes the reported failure depend on native stack depth | - | No |
 | `0040` | Assigns the C-function frame argument buffer | `js_call_c_function_data` and `js_call_c_closure` published a frame whose `arg_buf` was never set, so anything that walks frames precisely read an uninitialized buffer | - | No |
+| `0041` | Appends map and filter results directly to the dense result array | The generic define path turns every result index into an atom and re-derives, per element, that this is an append to a dense array | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -54,6 +54,7 @@ what we changed and why without opening a single `.patch` file.
 | `0041` | Appends map and filter results directly to the dense result array | The generic define path turns every result index into an atom and re-derives, per element, that this is an append to a dense array | - | No |
 | `0042` | Keeps an array dense when an index is skipped or deleted, by storing holes and tracking how many | Upstream demotes the array to a property table permanently the first time a store lands past the end, so `Array(n)`, gap fills, row-offset matrices and `delete` cost every later access | - | No |
 | `0043` | Stores the array/string iterator record inline and steps array iterators from the dense storage | Every iteration step re-read `length` with a property get and the element with a generic get; each iterator also allocated a record | - | No |
+| `0044` | Fills `slice` and `splice` results directly into the dense result array | The generic define path re-derives per element that the index appends to a dense array, and cannot see that the result was created with exactly that length | - | No |
 | `9999` | Raises the bytecode version number, once, for every patch above that needs it | Bytecode built by a patched engine must not load in an unpatched one. Doing it here rather than in each patch stops patches colliding on the same line | - | This is the bump |
 
 ## Reading the patches

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -163,12 +163,16 @@
       "sha256": "5631979871976a9c40220f51bf1e7908da609f2319c6cb1f4d71a4777f00cfe6"
     },
     {
+      "name": "0041-array-map-filter-fast-append.patch",
+      "sha256": "466416a907d91bb83fae02b4a57003897544a48d9b3b4941a257ab9c492829a1"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "732a8bdc23f8bed1bbd08b35098d325caa7e4996d0a5749a372e830c1005c586",
+    "quickjs.c": "d6edacb4e73d22e22066947159d508e63954e5238aa22bd95ae51b7181fbf0bc",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -175,12 +175,16 @@
       "sha256": "90a9f299d1e35daf3ccfd050f49bd45ecc81c18e5f9db21b4e8abbb6ba02db48"
     },
     {
+      "name": "0044-array-slice-direct-fill.patch",
+      "sha256": "e15dce3e352a1da91569e99e88be3532764180d5a3aab0022a3f1488729283f4"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "dca4fe16d0b004c38f988939a71b0c0d91999905684c4824609b33fd78cb1826",
+    "quickjs.c": "12795af81855e23188017aa867c4e065accf471b3d502725722e43465fc84f94",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -179,12 +179,16 @@
       "sha256": "e15dce3e352a1da91569e99e88be3532764180d5a3aab0022a3f1488729283f4"
     },
     {
+      "name": "0045-array-concat-direct-copy.patch",
+      "sha256": "b51577e3c5dfdb76e89419b5e4fbcc57b0a283a97ed3d2da08627c5c439945b8"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "12795af81855e23188017aa867c4e065accf471b3d502725722e43465fc84f94",
+    "quickjs.c": "1866ec6f00d23e81a1e740e88184b49726fffca5cdaf1738c874f29495e60fd5",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -183,12 +183,16 @@
       "sha256": "b51577e3c5dfdb76e89419b5e4fbcc57b0a283a97ed3d2da08627c5c439945b8"
     },
     {
+      "name": "0046-array-filter-reserve-capacity.patch",
+      "sha256": "9ff7fca7904c366b9f116ff284b23b30bfc816553ff1fa21760a21f6b159d70d"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "1866ec6f00d23e81a1e740e88184b49726fffca5cdaf1738c874f29495e60fd5",
+    "quickjs.c": "fc6994635bc1de167102c5f3fe8659dbf12b528d35c25afafdc0e1a16988a99d",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -171,12 +171,16 @@
       "sha256": "b30b7c2f5b3c9b3c9dbac20c3fa09107f88d539498f0a3ceac4de26fa19f1880"
     },
     {
+      "name": "0043-array-iterator-fast-step.patch",
+      "sha256": "90a9f299d1e35daf3ccfd050f49bd45ecc81c18e5f9db21b4e8abbb6ba02db48"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "8e2e335749a33c22fd9c6ace360a35f7a1aaf85fc5643f572d04b2a28fce15ad",
+    "quickjs.c": "dca4fe16d0b004c38f988939a71b0c0d91999905684c4824609b33fd78cb1826",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/MANIFEST.json
+++ b/engine/quickjs-rel/MANIFEST.json
@@ -167,12 +167,16 @@
       "sha256": "466416a907d91bb83fae02b4a57003897544a48d9b3b4941a257ab9c492829a1"
     },
     {
+      "name": "0042-holey-fast-arrays.patch",
+      "sha256": "b30b7c2f5b3c9b3c9dbac20c3fa09107f88d539498f0a3ceac4de26fa19f1880"
+    },
+    {
       "name": "9999-bc-version-bump.patch",
       "sha256": "2adbdaf59af795cc88e74b0cd9632dffcc330333a8cf2186305b410966502f76"
     }
   ],
   "files": {
-    "quickjs.c": "d6edacb4e73d22e22066947159d508e63954e5238aa22bd95ae51b7181fbf0bc",
+    "quickjs.c": "8e2e335749a33c22fd9c6ace360a35f7a1aaf85fc5643f572d04b2a28fce15ad",
     "libregexp.c": "98d43216a43bd02950168529fd8962558c9dda612eed7ce93d3cba40e1223232",
     "libunicode.c": "d755606498ff707dc3a93826713c749f77b9222d8a6b066621d72a308460bf2d",
     "dtoa.c": "a8d2cf2d04db406e0c16acdd95ab0e709d309902865722f41dac07a1ba5676af",

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -47644,11 +47644,69 @@ exception:
     return ret;
 }
 
+static JSObject *js_concat_direct_target(JSValueConst arr)
+{
+    JSObject *p;
+
+    if (JS_VALUE_GET_TAG(arr) != JS_TAG_OBJECT)
+        return NULL;
+    p = JS_VALUE_GET_OBJ(arr);
+    if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || !p->extensible)
+        return NULL;
+    if (p->holey || p->u.array.count != 0)
+        return NULL;
+    if (!(get_shape_prop(p->shape)->flags & JS_PROP_WRITABLE))
+        return NULL;
+    if (JS_VALUE_GET_TAG(p->prop[0].u.value) != JS_TAG_INT ||
+        JS_VALUE_GET_INT(p->prop[0].u.value) != 0)
+        return NULL;
+    return p;
+}
+
+static int js_concat_direct_append(JSContext *ctx, JSObject *p, int64_t n,
+                                   JSValueConst e)
+{
+    if (p->holey || p->u.array.count != (uint32_t)n || n >= INT32_MAX)
+        return 0;
+    if (p->u.array.u1.size <= (uint32_t)n &&
+        expand_fast_array(ctx, p, (uint32_t)n + 1) < 0)
+        return -1;
+    p->u.array.u.values[n] = js_dup(e);
+    p->u.array.count = (uint32_t)n + 1;
+    set_value(ctx, &p->prop[0].u.value, js_int32(n + 1));
+    return 1;
+}
+
+static int js_concat_direct_spread(JSContext *ctx, JSObject *p, int64_t n,
+                                   JSValueConst e, int64_t len)
+{
+    JSValue *arrp;
+    uint32_t count32, i;
+
+    if (len <= 0)
+        return 0;
+    if (p->holey || p->u.array.count != (uint32_t)n || n + len > INT32_MAX)
+        return 0;
+    if (JS_VALUE_GET_TAG(e) == JS_TAG_OBJECT && JS_VALUE_GET_OBJ(e) == p)
+        return 0;
+    if (!js_get_fast_array(ctx, e, &arrp, &count32) || (int64_t)count32 != len)
+        return 0;
+    if (p->u.array.u1.size < (uint32_t)(n + len) &&
+        expand_fast_array(ctx, p, (uint32_t)(n + len)) < 0)
+        return -1;
+    for (i = 0; i < (uint32_t)len; i++)
+        p->u.array.u.values[n + i] = js_dup(arrp[i]);
+    p->u.array.count = (uint32_t)(n + len);
+    set_value(ctx, &p->prop[0].u.value, js_int32(n + len));
+    return 1;
+}
+
 static JSValue js_array_concat(JSContext *ctx, JSValueConst this_val,
                                int argc, JSValueConst *argv)
 {
     JSValue obj, arr, val;
     JSValueConst e;
+    JSObject *dp;
     int64_t len, k, n;
     int i, res;
 
@@ -47660,6 +47718,7 @@ static JSValue js_array_concat(JSContext *ctx, JSValueConst this_val,
     arr = JS_ArraySpeciesCreate(ctx, obj, js_int32(0));
     if (JS_IsException(arr))
         goto exception;
+    dp = js_concat_direct_target(arr);
     n = 0;
     for (i = -1; i < argc; i++) {
         if (i < 0)
@@ -47677,6 +47736,15 @@ static JSValue js_array_concat(JSContext *ctx, JSValueConst this_val,
                 JS_ThrowTypeError(ctx, "Array loo long");
                 goto exception;
             }
+            if (dp != NULL) {
+                res = js_concat_direct_spread(ctx, dp, n, e, len);
+                if (res < 0)
+                    goto exception;
+                if (res) {
+                    n += len;
+                    continue;
+                }
+            }
             for (k = 0; k < len; k++, n++) {
                 res = JS_TryGetPropertyInt64(ctx, e, k, &val);
                 if (res < 0)
@@ -47691,6 +47759,15 @@ static JSValue js_array_concat(JSContext *ctx, JSValueConst this_val,
             if (n >= MAX_SAFE_INTEGER) {
                 JS_ThrowTypeError(ctx, "Array loo long");
                 goto exception;
+            }
+            if (dp != NULL) {
+                res = js_concat_direct_append(ctx, dp, n, e);
+                if (res < 0)
+                    goto exception;
+                if (res) {
+                    n++;
+                    continue;
+                }
             }
             if (JS_DefinePropertyValueInt64Const(ctx, arr, n, e,
                                                  JS_PROP_C_W_E | JS_PROP_THROW) < 0)

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -1340,6 +1340,12 @@ struct JSShape {
     uint32_t hash_table[]; /* prop_hash_mask + 1 elements, then prop[prop_size] */
 };
 
+typedef struct JSArrayIteratorData {
+    JSValue obj;
+    JSIteratorKindEnum kind;
+    uint32_t idx;
+} JSArrayIteratorData;
+
 struct JSObject {
     /* ref_count/gc_obj_type/mark live in the allocator block header; the object
        body keeps only the GC list link plus the object's own flags. */
@@ -1371,7 +1377,7 @@ struct JSObject {
         struct JSTypedArray *typed_array; /* JS_CLASS_UINT8C_ARRAY..JS_CLASS_DATAVIEW */
         struct JSMapState *map_state;   /* JS_CLASS_MAP..JS_CLASS_WEAKSET */
         struct JSMapIteratorData *map_iterator_data; /* JS_CLASS_MAP_ITERATOR, JS_CLASS_SET_ITERATOR */
-        struct JSArrayIteratorData *array_iterator_data; /* JS_CLASS_ARRAY_ITERATOR, JS_CLASS_STRING_ITERATOR */
+        JSArrayIteratorData array_iterator_data; /* JS_CLASS_ARRAY_ITERATOR, JS_CLASS_STRING_ITERATOR */
         struct JSRegExpStringIteratorData *regexp_string_iterator_data; /* JS_CLASS_REGEXP_STRING_ITERATOR */
         struct JSGeneratorData *generator_data; /* JS_CLASS_GENERATOR */
         struct JSIteratorConcatData *iterator_concat_data; /* JS_CLASS_ITERATOR_CONCAT */
@@ -9027,8 +9033,9 @@ void JS_ComputeMemoryUsage(JSRuntime *rt, JSMemoryUsage *s)
         case JS_CLASS_WEAKSET:           /* u.map_state */
         case JS_CLASS_MAP_ITERATOR:      /* u.map_iterator_data */
         case JS_CLASS_SET_ITERATOR:      /* u.map_iterator_data */
-        case JS_CLASS_ARRAY_ITERATOR:    /* u.array_iterator_data */
-        case JS_CLASS_STRING_ITERATOR:   /* u.array_iterator_data */
+        case JS_CLASS_ARRAY_ITERATOR:    /* u.array_iterator_data, stored inline */
+        case JS_CLASS_STRING_ITERATOR:   /* no separate block to account for */
+            break;
         case JS_CLASS_PROXY:             /* u.proxy_data */
         case JS_CLASS_PROMISE:           /* u.promise_data */
         case JS_CLASS_PROMISE_RESOLVE_FUNCTION:  /* u.promise_function_data */
@@ -49121,30 +49128,20 @@ exception:
     return ret;
 }
 
-typedef struct JSArrayIteratorData {
-    JSValue obj;
-    JSIteratorKindEnum kind;
-    uint32_t idx;
-} JSArrayIteratorData;
-
 static void js_array_iterator_finalizer(JSRuntime *rt, JSValueConst val)
 {
     JSObject *p = JS_VALUE_GET_OBJ(val);
-    JSArrayIteratorData *it = p->u.array_iterator_data;
-    if (it) {
-        JS_FreeValueRT(rt, it->obj);
-        js_free_rt(rt, it);
-    }
+    JSArrayIteratorData *it = &p->u.array_iterator_data;
+    JS_FreeValueRT(rt, it->obj);
+    it->obj = JS_UNDEFINED;
 }
 
 static void js_array_iterator_mark(JSRuntime *rt, JSValueConst val,
                                    JS_MarkFunc *mark_func)
 {
     JSObject *p = JS_VALUE_GET_OBJ(val);
-    JSArrayIteratorData *it = p->u.array_iterator_data;
-    if (it) {
-        JS_MarkValue(rt, it->obj, mark_func);
-    }
+    JSArrayIteratorData *it = &p->u.array_iterator_data;
+    JS_MarkValue(rt, it->obj, mark_func);
 }
 
 static JSValue js_create_array(JSContext *ctx, int len, JSValueConst *tab)
@@ -49193,16 +49190,11 @@ static JSValue js_create_array_iterator(JSContext *ctx, JSValueConst this_val,
     enum_obj = JS_NewObjectClass(ctx, class_id);
     if (JS_IsException(enum_obj))
         goto fail;
-    it = js_malloc(ctx, sizeof(*it));
-    if (!it)
-        goto fail1;
+    it = &JS_VALUE_GET_OBJ(enum_obj)->u.array_iterator_data;
     it->obj = arr;
     it->kind = kind;
     it->idx = 0;
-    JS_SetOpaqueInternal(enum_obj, it);
     return enum_obj;
- fail1:
-    JS_FreeValue(ctx, enum_obj);
  fail:
     JS_FreeValue(ctx, arr);
     return JS_EXCEPTION;
@@ -49217,11 +49209,43 @@ static JSValue js_array_iterator_next(JSContext *ctx, JSValueConst this_val,
     JSValue val, obj;
     JSObject *p;
 
-    it = JS_GetOpaque2(ctx, this_val, JS_CLASS_ARRAY_ITERATOR);
+    if (likely(JS_VALUE_GET_TAG(this_val) == JS_TAG_OBJECT &&
+               JS_VALUE_GET_OBJ(this_val)->class_id == JS_CLASS_ARRAY_ITERATOR)) {
+        it = &JS_VALUE_GET_OBJ(this_val)->u.array_iterator_data;
+    } else {
+        it = JS_GetOpaque2(ctx, this_val, JS_CLASS_ARRAY_ITERATOR);
+    }
     if (!it)
         goto fail1;
     if (JS_IsUndefined(it->obj))
         goto done;
+    {
+        JSObject *ap = JS_VALUE_GET_OBJ(it->obj);
+        if (likely(ap->class_id == JS_CLASS_ARRAY && ap->fast_array &&
+                   !ap->holey && it->idx < ap->u.array.count)) {
+            uint32_t i2 = it->idx;
+            it->idx = i2 + 1;
+            *pdone = false;
+            if (it->kind == JS_ITERATOR_KIND_KEY)
+                return js_uint32(i2);
+            if (js_lazy_marker_is(ap->u.array.u.values[i2]))
+                val = js_lazy_materialize_slot(ctx, &ap->u.array.u.values[i2], ap);
+            else
+                val = js_dup(ap->u.array.u.values[i2]);
+            if (it->kind == JS_ITERATOR_KIND_VALUE)
+                return val;
+            {
+                JSValueConst args2[2];
+                JSValue num2 = js_uint32(i2);
+                args2[0] = num2;
+                args2[1] = val;
+                obj = js_create_array(ctx, 2, args2);
+                JS_FreeValue(ctx, val);
+                JS_FreeValue(ctx, num2);
+                return obj;
+            }
+        }
+    }
     p = JS_VALUE_GET_OBJ(it->obj);
     if (is_typed_array(p->class_id)) {
         if (typed_array_is_oob(p)) {
@@ -52657,7 +52681,12 @@ static JSValue js_string_iterator_next(JSContext *ctx, JSValueConst this_val,
     uint32_t idx, c, start;
     JSString *p;
 
-    it = JS_GetOpaque2(ctx, this_val, JS_CLASS_STRING_ITERATOR);
+    if (likely(JS_VALUE_GET_TAG(this_val) == JS_TAG_OBJECT &&
+               JS_VALUE_GET_OBJ(this_val)->class_id == JS_CLASS_STRING_ITERATOR)) {
+        it = &JS_VALUE_GET_OBJ(this_val)->u.array_iterator_data;
+    } else {
+        it = JS_GetOpaque2(ctx, this_val, JS_CLASS_STRING_ITERATOR);
+    }
     if (!it) {
         *pdone = false;
         return JS_EXCEPTION;

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -47794,6 +47794,24 @@ exception:
 #define special_filter   4
 #define special_TA       8
 
+#define JS_FILTER_RESERVE_MAX 4096
+
+static void js_filter_reserve(JSContext *ctx, JSValueConst ret, int64_t len)
+{
+    JSObject *p;
+    int64_t cap;
+
+    if (JS_VALUE_GET_TAG(ret) != JS_TAG_OBJECT)
+        return;
+    p = JS_VALUE_GET_OBJ(ret);
+    if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || !p->extensible ||
+        p->holey || p->u.array.count != 0)
+        return;
+    cap = len < JS_FILTER_RESERVE_MAX ? len : JS_FILTER_RESERVE_MAX;
+    if (cap > 0 && p->u.array.u1.size < (uint32_t)cap)
+        expand_fast_array(ctx, p, (uint32_t)cap);
+}
+
 static JSObject *get_typed_array(JSContext *ctx, JSValueConst this_val)
 {
     JSObject *p;
@@ -47882,6 +47900,7 @@ static JSValue js_array_every(JSContext *ctx, JSValueConst this_val,
         ret = JS_ArraySpeciesCreate(ctx, obj, js_int32(0));
         if (JS_IsException(ret))
             goto exception;
+        js_filter_reserve(ctx, ret, len);
         break;
     case special_map | special_TA:
         args[0] = obj;

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -12765,11 +12765,34 @@ int JS_DefinePropertyValue(JSContext *ctx, JSValueConst this_obj,
     return ret;
 }
 
+static JSObject *js_fast_array_append_target(JSValueConst this_obj,
+                                             int64_t idx, int flags)
+{
+    JSObject *p;
+
+    if ((flags & ~JS_PROP_THROW) != JS_PROP_C_W_E)
+        return NULL;
+    if (JS_VALUE_GET_TAG(this_obj) != JS_TAG_OBJECT)
+        return NULL;
+    p = JS_VALUE_GET_OBJ(this_obj);
+    if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || !p->extensible)
+        return NULL;
+    if (idx != (int64_t)p->u.array.count)
+        return NULL;
+    return p;
+}
+
 int JS_DefinePropertyValueValue(JSContext *ctx, JSValueConst this_obj,
                                 JSValue prop, JSValue val, int flags)
 {
     JSAtom atom;
     int ret;
+    if (JS_VALUE_GET_TAG(prop) == JS_TAG_INT) {
+        JSObject *p = js_fast_array_append_target(
+            this_obj, JS_VALUE_GET_INT(prop), flags);
+        if (p != NULL)
+            return add_fast_array_element(ctx, p, val, flags) < 0 ? -1 : 0;
+    }
     atom = JS_ValueToAtom(ctx, prop);
     JS_FreeValue(ctx, prop);
     if (unlikely(atom == JS_ATOM_NULL)) {
@@ -12839,6 +12862,12 @@ static int JS_DefinePropertyValueInt64Const(JSContext *ctx, JSValueConst this_ob
 {
     JSAtom atom;
     int ret;
+    if (idx <= INT32_MAX) {
+        JSObject *p = js_fast_array_append_target(this_obj, idx, flags);
+        if (p != NULL)
+            return add_fast_array_element(ctx, p, js_dup(val), flags) < 0
+                ? -1 : 0;
+    }
     atom = JS_ValueToAtom(ctx, js_int64(idx));
     if (unlikely(atom == JS_ATOM_NULL))
         return -1;

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -48650,9 +48650,23 @@ static JSValue js_array_slice(JSContext *ctx, JSValueConst this_val,
     if (js_get_fast_array(ctx, obj, &arrp, &count32) &&
         js_is_fast_array(ctx, arr)) {
         /* XXX: should share code with fast array constructor */
-        for (; k < final && k < count32; k++, n++) {
-            if (JS_CreateDataPropertyUint32Const(ctx, arr, n, arrp[k], JS_PROP_THROW) < 0)
-                goto exception;
+        JSObject *ap = JS_VALUE_GET_OBJ(arr);
+        if (count > 0 && count <= INT32_MAX && final <= (int64_t)count32 &&
+            ap->extensible && ap->u.array.count == 0 &&
+            JS_VALUE_GET_TAG(ap->prop[0].u.value) == JS_TAG_INT &&
+            JS_VALUE_GET_INT(ap->prop[0].u.value) == count &&
+            (ap->u.array.u1.size >= (uint32_t)count ||
+             expand_fast_array(ctx, ap, count) == 0)) {
+            for (i = 0; i < (uint32_t)count; i++)
+                ap->u.array.u.values[i] = js_dup(arrp[start + i]);
+            ap->u.array.count = count;
+            n = count;
+            k = final;
+        } else {
+            for (; k < final && k < count32; k++, n++) {
+                if (JS_CreateDataPropertyUint32Const(ctx, arr, n, arrp[k], JS_PROP_THROW) < 0)
+                    goto exception;
+            }
         }
     }
     /* Copy the remaining elements if any (handle case of inherited properties) */

--- a/engine/quickjs-rel/quickjs.c
+++ b/engine/quickjs-rel/quickjs.c
@@ -1349,6 +1349,7 @@ struct JSObject {
     uint8_t free_mark : 1; /* only used when freeing objects with cycles */
     uint8_t is_exotic : 1; /* true if object has exotic property handlers */
     uint8_t fast_array : 1; /* true if u.array is used for get/put (for JS_CLASS_ARRAY, JS_CLASS_ARGUMENTS, JS_CLASS_MAPPED_ARGUMENTS and typed arrays) */
+    uint8_t holey : 1;
     uint8_t is_constructor : 1; /* true if object is a constructor function */
     uint8_t is_uncatchable_error : 1; /* if true, error is not catchable */
     uint8_t tmp_mark : 1; /* used in JS_WriteObjectRec() */
@@ -1418,12 +1419,16 @@ struct JSObject {
                 double *double_ptr;     /* JS_CLASS_FLOAT64_ARRAY */
             } u;
             uint32_t count; /* <= 2^31-1. 0 for a detached typed array */
-        } array;    /* 12/20 bytes */
+            uint32_t hole_count; /* JS_CLASS_ARRAY only, valid while p->holey */
+        } array;    /* 16/24 bytes */
         JSRegExp regexp;    /* JS_CLASS_REGEXP: 8/16 bytes */
         JSValue object_data;    /* for JS_SetObjectData(): 8/16/16 bytes */
     } u;
     /* byte sizes: 40/48/72 */
 };
+
+_Static_assert(sizeof(((JSObject *)0)->u.array) <= sizeof(((JSObject *)0)->u.func),
+               "u.array outgrew u.func");
 
 typedef struct JSCallSiteData {
     JSValue filename;
@@ -3196,6 +3201,11 @@ static inline void set_value(JSContext *ctx, JSValue *pval, JSValue new_val)
     old_val = *pval;
     *pval = new_val;
     JS_FreeValue(ctx, old_val);
+}
+
+static inline bool js_array_slot_is_hole(JSValueConst v)
+{
+    return JS_VALUE_GET_TAG(v) == JS_TAG_UNINITIALIZED;
 }
 
 void JS_SetClassProto(JSContext *ctx, JSClassID class_id, JSValue obj)
@@ -7218,6 +7228,7 @@ static JSValue JS_NewObjectFromShape(JSContext *ctx, JSShape *sh, JSClassID clas
     p->free_mark = 0;
     p->is_exotic = 0;
     p->fast_array = 0;
+    p->holey = 0;
     p->is_constructor = 0;
     p->is_uncatchable_error = 0;
     p->tmp_mark = 0;
@@ -7251,6 +7262,7 @@ static JSValue JS_NewObjectFromShape(JSContext *ctx, JSShape *sh, JSClassID clas
             p->fast_array = 1;
             p->u.array.u.values = NULL;
             p->u.array.count = 0;
+            p->u.array.hole_count = 0;
             p->u.array.u1.size = 0;
             if (!props) {
                 /* XXX: remove */
@@ -10415,7 +10427,9 @@ static JSValue JS_GetPropertyInternal(JSContext *ctx, JSValueConst obj,
             if (p->fast_array) {
                 if (__JS_AtomIsTaggedInt(prop)) {
                     uint32_t idx = __JS_AtomToUInt32(prop);
-                    if (idx < p->u.array.count) {
+                    if (idx < p->u.array.count &&
+                        !(p->holey &&
+                          js_array_slot_is_hole(p->u.array.u.values[idx]))) {
                         /* we avoid duplicating the code */
                         return JS_GetPropertyUint32(ctx, JS_MKPTR(JS_TAG_OBJECT, p), idx);
                     } else if (is_typed_array(p->class_id)) {
@@ -10787,6 +10801,8 @@ static int __exception JS_GetOwnPropertyNamesInternal(JSContext *ctx,
         if (p->fast_array) {
             if (flags & JS_GPN_STRING_MASK) {
                 num_keys_count += p->u.array.count;
+                if (unlikely(p->holey))
+                    num_keys_count -= p->u.array.hole_count;
             }
         } else if (p->class_id == JS_CLASS_STRING) {
             if (flags & JS_GPN_STRING_MASK) {
@@ -10868,7 +10884,21 @@ static int __exception JS_GetOwnPropertyNamesInternal(JSContext *ctx,
         if (p->fast_array) {
             if (flags & JS_GPN_STRING_MASK) {
                 len = p->u.array.count;
-                goto add_array_keys;
+                if (unlikely(p->holey)) {
+                    for(i = 0; i < len; i++) {
+                        if (js_array_slot_is_hole(p->u.array.u.values[i]))
+                            continue;
+                        tab_atom[num_index].atom = __JS_AtomFromUInt32(i);
+                        if (tab_atom[num_index].atom == JS_ATOM_NULL) {
+                            js_free_prop_enum(ctx, tab_atom, num_index);
+                            return -1;
+                        }
+                        tab_atom[num_index].is_enumerable = true;
+                        num_index++;
+                    }
+                } else {
+                    goto add_array_keys;
+                }
             }
         } else if (p->class_id == JS_CLASS_STRING) {
             if (flags & JS_GPN_STRING_MASK) {
@@ -10998,7 +11028,9 @@ retry:
             if (__JS_AtomIsTaggedInt(prop)) {
                 uint32_t idx;
                 idx = __JS_AtomToUInt32(prop);
-                if (idx < p->u.array.count) {
+                if (idx < p->u.array.count &&
+                    !(p->holey &&
+                      js_array_slot_is_hole(p->u.array.u.values[idx]))) {
                     if (desc) {
                         desc->flags = JS_PROP_WRITABLE | JS_PROP_ENUMERABLE |
                             JS_PROP_CONFIGURABLE;
@@ -11183,6 +11215,18 @@ static bool js_get_fast_array_element(JSContext *ctx, JSObject *p,
 {
     switch(p->class_id) {
     case JS_CLASS_ARRAY:
+        {
+            JSValue v;
+            if (unlikely(idx >= p->u.array.count)) return false;
+            v = p->u.array.u.values[idx];
+            if (unlikely(JS_VALUE_GET_TAG(v) == JS_TAG_UNINITIALIZED))
+                return false;
+            if (js_lazy_marker_is(v))
+                *pval = js_lazy_materialize_slot(ctx, &p->u.array.u.values[idx], p);
+            else
+                *pval = js_dup(v);
+            return true;
+        }
     case JS_CLASS_ARGUMENTS:
         if (unlikely(idx >= p->u.array.count)) return false;
         if (js_lazy_marker_is(p->u.array.u.values[idx]))
@@ -11451,17 +11495,22 @@ static no_inline __exception int convert_fast_array_to_array(JSContext *ctx,
     } else {
         JSValue *tab = p->u.array.u.values;
         for(i = 0; i < len; i++) {
+            JSValue v = *tab++;
+            if (unlikely(js_array_slot_is_hole(v)))
+                continue;
             /* add_property cannot fail here but
                __JS_AtomFromUInt32(i) fails for i > INT32_MAX */
             pr = add_property(ctx, p, __JS_AtomFromUInt32(i), JS_PROP_C_W_E);
-            pr->u.value = *tab++;
+            pr->u.value = v;
         }
     }
     js_free(ctx, p->u.array.u.values);
     p->u.array.count = 0;
+    p->u.array.hole_count = 0;
     p->u.array.u.values = NULL; /* fail safe */
     p->u.array.u1.size = 0;
     p->fast_array = 0;
+    p->holey = 0;
     return 0;
 }
 
@@ -11529,8 +11578,20 @@ static int delete_property(JSContext *ctx, JSObject *p, JSAtom atom)
             uint32_t idx;
             if (JS_AtomIsArrayIndex(ctx, &idx, atom) &&
                 idx < p->u.array.count) {
-                if (p->class_id == JS_CLASS_ARRAY ||
-                    p->class_id == JS_CLASS_ARGUMENTS ||
+                if (p->class_id == JS_CLASS_ARRAY) {
+                    JSValue v = p->u.array.u.values[idx];
+                    if (js_array_slot_is_hole(v))
+                        return true;              /* already absent */
+                    p->u.array.u.values[idx] = JS_UNINITIALIZED;
+                    if (!p->holey) {
+                        p->holey = 1;
+                        p->u.array.hole_count = 0;
+                    }
+                    p->u.array.hole_count++;
+                    JS_FreeValue(ctx, v);
+                    return true;
+                }
+                if (p->class_id == JS_CLASS_ARGUMENTS ||
                     p->class_id == JS_CLASS_MAPPED_ARGUMENTS) {
                     if (convert_fast_array_to_array(ctx, p))
                         return -1;
@@ -11594,6 +11655,11 @@ static int set_array_length(JSContext *ctx, JSObject *p, JSValue val,
         uint32_t old_len = p->u.array.count;
         if (len < old_len) {
             for(i = len; i < old_len; i++) {
+                if (unlikely(p->holey) &&
+                    js_array_slot_is_hole(p->u.array.u.values[i])) {
+                    if (--p->u.array.hole_count == 0)
+                        p->holey = 0;
+                }
                 JS_FreeValue(ctx, p->u.array.u.values[i]);
                 p->u.array.u.values[i] = JS_UNDEFINED;
             }
@@ -11725,6 +11791,88 @@ static int add_fast_array_element(JSContext *ctx, JSObject *p,
     return true;
 }
 
+
+#define JS_ARRAY_HOLE_MAX_GAP     256
+#define JS_ARRAY_HOLE_DENSE_FLOOR 256
+#define JS_ARRAY_HOLE_MIN_DENSITY 4
+
+static inline bool js_array_can_fill_hole_fast(JSContext *ctx, JSObject *p)
+{
+    return p->extensible &&
+        p->shape->proto == JS_VALUE_GET_OBJ(ctx->class_proto[JS_CLASS_ARRAY]) &&
+        ctx->std_array_prototype;
+}
+
+static int js_array_store_hole_gap(JSContext *ctx, JSObject *p, uint32_t idx,
+                                   JSValue val)
+{
+    uint32_t count, gap, new_count, elems, array_len, i;
+
+    count = p->u.array.count;
+    gap = idx - count;
+    if (gap > JS_ARRAY_HOLE_MAX_GAP)
+        return 0;
+    if (idx >= (uint32_t)INT32_MAX)
+        return 0;
+    new_count = idx + 1;
+    elems = new_count - ((p->holey ? p->u.array.hole_count : 0) + gap);
+    if (new_count > JS_ARRAY_HOLE_DENSE_FLOOR &&
+        elems * (uint64_t)JS_ARRAY_HOLE_MIN_DENSITY < new_count)
+        return 0;
+    if (unlikely(JS_VALUE_GET_TAG(p->prop[0].u.value) != JS_TAG_INT))
+        return 0;
+    array_len = JS_VALUE_GET_INT(p->prop[0].u.value);
+    if (new_count > array_len &&
+        unlikely(!(get_shape_prop(p->shape)->flags & JS_PROP_WRITABLE)))
+        return 0;
+    if (new_count > p->u.array.u1.size) {
+        if (expand_fast_array(ctx, p, new_count)) {
+            JS_FreeValue(ctx, val);
+            return -1;
+        }
+    }
+    for (i = count; i < idx; i++)
+        p->u.array.u.values[i] = JS_UNINITIALIZED;
+    p->u.array.u.values[idx] = val;
+    p->u.array.count = new_count;
+    if (new_count > array_len)
+        p->prop[0].u.value = js_int32(new_count);
+    if (!p->holey) {
+        p->holey = 1;
+        p->u.array.hole_count = 0;
+    }
+    p->u.array.hole_count += gap;
+    return 1;
+}
+
+static void js_array_fill_hole(JSObject *p, uint32_t idx, JSValue val)
+{
+    assert(p->holey && js_array_slot_is_hole(p->u.array.u.values[idx]));
+    p->u.array.u.values[idx] = val;
+    if (--p->u.array.hole_count == 0)
+        p->holey = 0;
+}
+
+static bool js_array_try_repack(JSObject *p)
+{
+    uint32_t i, count, holes;
+
+    if (p->u.array.hole_count == 0) {   /* kept exact; this is the usual exit */
+        p->holey = 0;
+        return true;
+    }
+    count = p->u.array.count;
+    holes = 0;
+    for (i = 0; i < count; i++)
+        holes += js_array_slot_is_hole(p->u.array.u.values[i]);
+    p->u.array.hole_count = holes;
+    if (holes == 0) {
+        p->holey = 0;
+        return true;
+    }
+    return false;
+}
+
 /* Allocate a new fast array initialized to JS_UNDEFINED. Its maximum
    size is 2^31-1 elements. For convenience, 'len' is a 64 bit
    integer. */
@@ -11835,7 +11983,9 @@ retry:
             if (p1->fast_array) {
                 if (__JS_AtomIsTaggedInt(prop)) {
                     uint32_t idx = __JS_AtomToUInt32(prop);
-                    if (idx < p1->u.array.count) {
+                    if (idx < p1->u.array.count &&
+                        !(p1->holey &&
+                          js_array_slot_is_hole(p1->u.array.u.values[idx]))) {
                         if (unlikely(p == p1))
                             return JS_SetPropertyValue(ctx, this_obj, js_int32(idx), val, flags);
                         else
@@ -12065,6 +12215,13 @@ static int JS_SetPropertyValue(JSContext *ctx, JSValueConst this_obj,
                 /* add element */
                 return add_fast_array_element(ctx, p, val, flags);
             }
+            if (unlikely(p->holey) &&
+                js_array_slot_is_hole(p->u.array.u.values[idx])) {
+                if (unlikely(!js_array_can_fill_hole_fast(ctx, p)))
+                    goto slow_path;
+                js_array_fill_hole(p, idx, val);
+                break;
+            }
             set_value(ctx, &p->u.array.u.values[idx], val);
             break;
         case JS_CLASS_ARGUMENTS:
@@ -12274,6 +12431,24 @@ static int JS_CreateProperty(JSContext *ctx, JSObject *p,
                         return add_fast_array_element(ctx, p,
                                                       js_dup(val), flags);
                     } else {
+                        if (!p->extensible)
+                            goto not_extensible;
+                        if (flags & (JS_PROP_HAS_GET | JS_PROP_HAS_SET))
+                            goto convert_to_array;
+                        if (get_prop_flags(flags, 0) != JS_PROP_C_W_E)
+                            goto convert_to_array;
+                        if (idx < p->u.array.count) {
+                            assert(p->holey &&
+                                   js_array_slot_is_hole(p->u.array.u.values[idx]));
+                            js_array_fill_hole(p, idx, js_dup(val));
+                            return true;
+                        }
+                        ret = js_array_store_hole_gap(ctx, p, idx,
+                                                      js_dup(val));
+                        if (ret < 0)
+                            return -1;
+                        if (ret > 0)
+                            return true;
                         goto convert_to_array;
                     }
                 } else if (JS_AtomIsArrayIndex(ctx, &idx, prop)) {
@@ -12649,7 +12824,9 @@ int JS_DefineProperty(JSContext *ctx, JSValueConst this_obj,
         if (p->class_id == JS_CLASS_ARRAY) {
             if (__JS_AtomIsTaggedInt(prop)) {
                 idx = __JS_AtomToUInt32(prop);
-                if (idx < p->u.array.count) {
+                if (idx < p->u.array.count &&
+                    !(p->holey &&
+                      js_array_slot_is_hole(p->u.array.u.values[idx]))) {
                     prop_flags = get_prop_flags(flags, JS_PROP_C_W_E);
                     if (prop_flags != JS_PROP_C_W_E)
                         goto convert_to_slow_array;
@@ -18668,13 +18845,14 @@ static bool js_is_fast_array(JSContext *ctx, JSValue obj)
     if (JS_VALUE_GET_TAG(obj) == JS_TAG_OBJECT) {
         JSObject *p = JS_VALUE_GET_OBJ(obj);
         if (p->class_id == JS_CLASS_ARRAY && p->fast_array) {
+            if (unlikely(p->holey) && !js_array_try_repack(p))
+                return false;
             return true;
         }
     }
     return false;
 }
 
-/* Access an Array's internal JSValue array if available */
 static bool js_get_fast_array(JSContext *ctx, JSValue obj,
                               JSValue **arrpp, uint32_t *countp)
 {
@@ -18682,6 +18860,8 @@ static bool js_get_fast_array(JSContext *ctx, JSValue obj,
     if (JS_VALUE_GET_TAG(obj) == JS_TAG_OBJECT) {
         JSObject *p = JS_VALUE_GET_OBJ(obj);
         if (p->class_id == JS_CLASS_ARRAY && p->fast_array) {
+            if (unlikely(p->holey) && !js_array_try_repack(p))
+                return false;
             *countp = p->u.array.count;
             *arrpp = p->u.array.u.values;
             return true;
@@ -22024,7 +22204,8 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     JSObject *p = JS_VALUE_GET_OBJ(sp[-2]);
                     uint32_t idx = JS_VALUE_GET_INT(sp[-1]);
                     if (likely(p->class_id == JS_CLASS_ARRAY &&
-                               idx < p->u.array.count)) {
+                               idx < p->u.array.count &&
+                               !js_array_slot_is_hole(p->u.array.u.values[idx]))) {
                         if (js_lazy_marker_is(p->u.array.u.values[idx]))
                             val = js_lazy_materialize_slot(ctx, &p->u.array.u.values[idx], p);
                         else
@@ -22061,7 +22242,8 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     JSObject *p = JS_VALUE_GET_OBJ(sp[-2]);
                     uint32_t idx = JS_VALUE_GET_INT(sp[-1]);
                     if (likely(p->class_id == JS_CLASS_ARRAY &&
-                               idx < p->u.array.count)) {
+                               idx < p->u.array.count &&
+                               !js_array_slot_is_hole(p->u.array.u.values[idx]))) {
                         if (js_lazy_marker_is(p->u.array.u.values[idx]))
                             sp[-1] = js_lazy_materialize_slot(ctx, &p->u.array.u.values[idx], p);
                         else
@@ -22135,7 +22317,8 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     if (likely(JS_VALUE_GET_TAG(sp[-3]) == JS_TAG_OBJECT)) {
                         p = JS_VALUE_GET_OBJ(sp[-3]);
                         if (likely(p->class_id == JS_CLASS_ARRAY &&
-                                   idx < (uint32_t)p->u.array.count)) {
+                                   idx < (uint32_t)p->u.array.count &&
+                                   !js_array_slot_is_hole(p->u.array.u.values[idx]))) {
                             set_value(ctx, &p->u.array.u.values[idx], val);
                             JS_FreeValue(ctx, sp[-3]);
                             sp -= 3;
@@ -46530,6 +46713,7 @@ static JSValue *build_arg_list(JSContext *ctx, uint32_t *plen,
     p = JS_VALUE_GET_OBJ(array_arg);
     if ((p->class_id == JS_CLASS_ARRAY || p->class_id == JS_CLASS_ARGUMENTS) &&
         p->fast_array &&
+        !p->holey &&
         len == p->u.array.count) {
         for(i = 0; i < len; i++) {
             tab[i] = js_dup(p->u.array.u.values[i]);
@@ -47058,7 +47242,7 @@ static int JS_CopySubArray(JSContext *ctx,
     p = NULL;
     if (JS_VALUE_GET_TAG(obj) == JS_TAG_OBJECT) {
         p = JS_VALUE_GET_OBJ(obj);
-        if (p->class_id != JS_CLASS_ARRAY || !p->fast_array) {
+        if (p->class_id != JS_CLASS_ARRAY || !p->fast_array || p->holey) {
             p = NULL;
         }
     }
@@ -47071,7 +47255,7 @@ static int JS_CopySubArray(JSContext *ctx,
             from = from_pos + i;
             to = to_pos + i;
         }
-        if (p && p->fast_array &&
+        if (p && p->fast_array && !p->holey &&
             from >= 0 && from < (len = p->u.array.count)  &&
             to >= 0 && to < len) {
             int64_t l, j;


### PR DESCRIPTION
Six changes to the engine's array paths, each keeping the existing path for every case it cannot prove safe. Together they move the sampled Octane suite from `0040` to the branch tip by **+5.54% geomean**, driven by crypto (+23.7%)
and pdfjs (+22.4%), the two rows whose element accesses were previously landing on demoted arrays.

The element-level wins are much larger, because these shapes do their work per element: appending `map`/`filter` results in place is up to 25.2% cheaper, holding an array dense through a skipped or deleted index up to 52.8%, iterating an array 33.3% (`for...of`) and 11.1% (destructuring), copying a range with `slice` up to 74%, concatenating `concat` up to 85%, and reserving `filter` result capacity 8.3%.

The control shapes are unchanged: an indexed `for` loop, a fill that never opens a gap, a fill past the hole cap, a slice of an array-like, an empty slice, a concat whose inputs keep the generic path, and a filter that keeps nothing (which pays about 1% for its reservation).

| patch | what it does |
|---|---|
| `0041` | Appends `Array.prototype.map` and `filter` results straight into the dense result array, instead of defining every result index through the generic path. |
| `0042` | Keeps a fast array dense when an index is skipped or deleted by storing holes and counting them, instead of demoting the object to a property table permanently. |
| `0043` | Stores the array and string iterator record inline, in place of its own allocation, and serves a step over a dense array straight from that record, removing the per-step `length` and element property gets. |
| `0044` | Fills `slice` and `splice` results straight into the dense result array, growing it once, instead of defining every index through the generic path. |
| `0045` | Copies `concat` inputs that are already dense fast arrays straight into the result, growing it once per input, instead of reading and defining every element. |
| `0046` | Reserves fast-array capacity for the `filter` result from the input length, capped at 4096 slots, instead of letting it grow through repeated reallocation. |

## Microbenchmarks (interleaved, min of 4 runs, lower is better)

| patch | shape | before | after | gain |
|---|---|---:|---:|---:|
| `0041` | `map` identity | 302 | 226 | **+25.2%** |
| | `filter` keep-all | 321 | 257 | **+19.9%** |
| | `map` to objects | 678 | 599 | **+11.7%** |
| `0042` | fill from index 2 | 144 | 68 | **+52.8%** |
| | delete every other | 220 | 181 | **+17.7%** |
| | read across a gap | 476 | 451 | **+5.3%** |
| | fill from 0 (control) | 68 | 68 | 0.0% |
| | full reverse fill (control) | 138 | 139 | −0.7% |
| `0043` | `for...of` over an array | 12 | 8 | **+33.3%** |
| | array destructuring | 9 | 8 | **+11.1%** |
| | `.values()` | 62 | 57 | **+8.1%** |
| | `.entries()` | 58 | 54 | **+6.9%** |
| | `.keys()` | 61 | 58 | **+4.9%** |
| | indexed `for` (control) | 13 | 13 | 0.0% |
| `0044` | slice, 200 elements | 62 | 16 | **+74.2%** |
| | slice, 50-element window | 40 | 12 | **+70.0%** |
| | slice, 100,000 elements | 179 | 54 | **+69.8%** |
| | slice of an array-like (control) | 157 | 158 | −0.6% |
| | empty slice (control) | 6 | 6 | 0.0% |
| `0045` | concat, two 200-element arrays | 196 | 30 | **+84.7%** |
| | concat, four 100-element arrays | 198 | 39 | **+80.3%** |
| | concat, a scalar | 105 | 20 | **+81.0%** |
| | concat, two 20,000-element arrays | 580 | 150 | **+74.1%** |
| | concat, generic path (control) | 163 | 163 | 0.0% |
| `0046` | filter, keep-all | 254 | 233 | **+8.3%** |
| | filter, keep-half | 239 | 221 | **+7.5%** |
| | filter, 20,000 elements | 662 | 613 | **+7.4%** |
| | filter, 100,000 elements | 1536 | 1420 | **+7.6%** |
| | filter, keeps nothing (control) | 193 | 195 | −1.0% |

## Octane (max of 4 rotated runs per row, higher is better)

| row | 0040 | tip | gain |
|---|---:|---:|---:|
| crypto | 520 | 643 | **+23.7%** |
| pdfjs | 2307 | 2824 | **+22.4%** |
| gbemu | 3673 | 3754 | +2.2% |
| navierstokes | 1009 | 1030 | +2.1% |
| splay | 3812 | 3831 | +0.5% |
| typescript | 7995 | 8018 | +0.3% |
| deltablue | 653 | 646 | −1.1% |
| richards | 673 | 658 | −2.2% |
| **geomean (8 rows)** | | | **+5.54%** |

Validation: for every patch, 15/15 ctest, the differential and bytecode suites, and a semantics probe whose output is byte-identical to the branch before it. Full test262 is unchanged at 52/81,192.